### PR TITLE
API: Changes loss graph API to work off of AbstractLossGraph objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ class SimpleLossGraph(tensorrec.loss_graphs.AbstractLossGraph):
         return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
 # Build a model with the custom loss function
-model = tensorrec.TensorRec(loss_graph=SimpleLossGraph())
+model = tensorrec.TensorRec(loss_graph=SimpleLossGraph)
 
 # Generate some dummy data
 interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ model = tensorrec.TensorRec(user_repr_graph=tanh_representation_graph,
 import tensorflow as tf
 import tensorrec
 
-# Define a custom loss function graph
+# Define a custom loss graph
 class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
     def loss_graph(self, tf_prediction, tf_y, **kwargs):
         """

--- a/README.md
+++ b/README.md
@@ -113,20 +113,21 @@ import tensorflow as tf
 import tensorrec
 
 # Define a custom loss function graph
-def simple_error_graph(tf_prediction_serial, tf_interactions_serial, **kwargs):
-    """
-    This loss function returns the absolute simple error between the predictions and the interactions.
-    :param tf_prediction_serial: tf.Tensor
-    The recommendation scores as a Tensor of shape [n_samples, 1]
-    :param tf_interactions_serial: tf.Tensor
-    The sample interactions corresponding to tf_prediction as a Tensor of shape [n_samples, 1]
-    :param kwargs:
-    Other TensorFlow nodes (not yet implemented)
-    :return:
-    A tf.Tensor containing the learning loss.
-    """
-    return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
+class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
+    def loss_graph(self, tf_prediction, tf_y, **kwargs):
+        """
+        This loss function returns the absolute simple error between the predictions and the interactions.
+        :param tf_prediction_serial: tf.Tensor
+        The recommendation scores as a Tensor of shape [n_samples, 1]
+        :param tf_interactions_serial: tf.Tensor
+        The sample interactions corresponding to tf_prediction as a Tensor of shape [n_samples, 1]
+        :param kwargs:
+        Other TensorFlow nodes.
+        :return:
+        A tf.Tensor containing the learning loss.
+        """
+        return tf.reduce_mean(tf.abs(tf_y - tf_prediction))
 
 # Build a model with the custom loss function
-model = tensorrec.TensorRec(loss_graph=simple_error_graph)
+model = tensorrec.TensorRec(loss_graph=SimpleLoss())
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ import tensorflow as tf
 import tensorrec
 
 # Define a custom loss graph
-class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
+class SimpleLossGraph(tensorrec.loss_graphs.AbstractLossGraph):
     def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
         """
         This loss function returns the absolute simple error between the predictions and the interactions.
@@ -137,7 +137,7 @@ class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
         return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
 # Build a model with the custom loss function
-model = tensorrec.TensorRec(loss_graph=SimpleLoss())
+model = tensorrec.TensorRec(loss_graph=SimpleLossGraph())
 
 # Generate some dummy data
 interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ def tanh_representation_graph(tf_features, n_components, n_features, node_name_e
 # Build a model with the custom representation function
 model = tensorrec.TensorRec(user_repr_graph=tanh_representation_graph,
                             item_repr_graph=tanh_representation_graph)
+
+# Generate some dummy data
+interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,
+                                                                                num_items=150,
+                                                                                interaction_density=.05)
+
+# Fit the model for 5 epochs
+model.fit(interactions, user_features, item_features, epochs=5, verbose=True)
 ```
 
 ## Example: Defining custom loss function
@@ -130,4 +138,12 @@ class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
 
 # Build a model with the custom loss function
 model = tensorrec.TensorRec(loss_graph=SimpleLoss())
+
+# Generate some dummy data
+interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,
+                                                                                num_items=150,
+                                                                                interaction_density=.05)
+
+# Fit the model for 5 epochs
+model.fit(interactions, user_features, item_features, epochs=5, verbose=True)
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import tensorrec
 
 # Define a custom loss graph
 class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
-    def loss_graph(self, tf_prediction, tf_y, **kwargs):
+    def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
         """
         This loss function returns the absolute simple error between the predictions and the interactions.
         :param tf_prediction_serial: tf.Tensor
@@ -134,7 +134,7 @@ class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
         :return:
         A tf.Tensor containing the learning loss.
         """
-        return tf.reduce_mean(tf.abs(tf_y - tf_prediction))
+        return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
 # Build a model with the custom loss function
 model = tensorrec.TensorRec(loss_graph=SimpleLoss())

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
         :param tf_prediction_serial: tf.Tensor
         The recommendation scores as a Tensor of shape [n_samples, 1]
         :param tf_interactions_serial: tf.Tensor
-        The sample interactions corresponding to tf_prediction as a Tensor of shape [n_samples, 1]
+        The sample interactions corresponding to tf_prediction_serial as a Tensor of shape [n_samples, 1]
         :param kwargs:
         Other TensorFlow nodes.
         :return:

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -1,93 +1,102 @@
+import abc
 import tensorflow as tf
 
 
-def rmse_loss(tf_prediction_serial, tf_interactions_serial, **kwargs):
+class AbstractLossGraph(object):
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, is_dense=False):
+        self.is_dense = is_dense
+
+    @abc.abstractmethod
+    def loss_graph(self, tf_prediction_serial, tf_interactions_serial, tf_prediction, tf_interactions, tf_rankings,
+                   tf_alignment):
+        """
+        TODO document
+        :param tf_prediction_serial:
+        :param tf_interactions_serial:
+        :param tf_prediction:
+        :param tf_interactions:
+        :param tf_rankings:
+        :param tf_alignment:
+        :return:
+        """
+        pass
+
+
+class RMSELoss(AbstractLossGraph):
     """
     This loss function returns the root mean square error between the predictions and the true interactions.
     Interactions can be any positive or negative values, and this loss function is sensitive to magnitude.
-    :param tf_prediction_serial:
-    :param tf_interactions_serial:
-    :return:
     """
-    return tf.sqrt(tf.reduce_mean(tf.square(tf_interactions_serial - tf_prediction_serial)))
+    def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
+        return tf.sqrt(tf.reduce_mean(tf.square(tf_interactions_serial - tf_prediction_serial)))
 
 
-def separation_loss(tf_prediction_serial, tf_interactions_serial, **kwargs):
+class SeparationLoss(AbstractLossGraph):
     """
     This loss function models the explicit positive and negative interaction predictions as normal distributions and
     returns the probability of overlap between the two distributions.
     Interactions can be any positive or negative values, but this loss function ignored the magnitude of the
     interaction -- interactions are grouped in to {i < 0} and {i > 0}.
-    :param tf_prediction_serial:
-    :param tf_interactions_serial:
-    :return:
     """
+    def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
 
-    tf_positive_mask = tf.greater(tf_interactions_serial, 0.0)
-    tf_negative_mask = tf.less_equal(tf_interactions_serial, 0.0)
+        tf_positive_mask = tf.greater(tf_interactions_serial, 0.0)
+        tf_negative_mask = tf.less_equal(tf_interactions_serial, 0.0)
 
-    tf_positive_predictions = tf.boolean_mask(tf_prediction_serial, tf_positive_mask)
-    tf_negative_predictions = tf.boolean_mask(tf_prediction_serial, tf_negative_mask)
+        tf_positive_predictions = tf.boolean_mask(tf_prediction_serial, tf_positive_mask)
+        tf_negative_predictions = tf.boolean_mask(tf_prediction_serial, tf_negative_mask)
 
-    tf_pos_mean, tf_pos_var = tf.nn.moments(tf_positive_predictions, axes=[0])
-    tf_neg_mean, tf_neg_var = tf.nn.moments(tf_negative_predictions, axes=[0])
+        tf_pos_mean, tf_pos_var = tf.nn.moments(tf_positive_predictions, axes=[0])
+        tf_neg_mean, tf_neg_var = tf.nn.moments(tf_negative_predictions, axes=[0])
 
-    tf_overlap_distribution = tf.contrib.distributions.Normal(loc=(tf_neg_mean - tf_pos_mean),
-                                                              scale=tf.sqrt(tf_neg_var + tf_pos_var))
+        tf_overlap_distribution = tf.contrib.distributions.Normal(loc=(tf_neg_mean - tf_pos_mean),
+                                                                  scale=tf.sqrt(tf_neg_var + tf_pos_var))
 
-    loss = 1.0 - tf_overlap_distribution.cdf(0.0)
-    return loss
+        loss = 1.0 - tf_overlap_distribution.cdf(0.0)
+        return loss
 
 
-def wmrb_loss(tf_interactions, tf_prediction, **kwargs):
+class WMRBLoss(AbstractLossGraph):
     """
     Approximation of http://ceur-ws.org/Vol-1905/recsys2017_poster3.pdf
     Interactions can be any positive values, but magnitude is ignored. Negative interactions are also ignored.
-    :param tf_interactions:
-    :param tf_prediction:
-    :param kwargs:
-    :return:
     """
+    def __init__(self):
+        super(WMRBLoss, self).__init__(is_dense=True)
 
-    positive_interaction_mask = tf.greater(tf_interactions.values, 0.0)
-    positive_interaction_indices = tf.boolean_mask(tf_interactions.indices,
-                                                   positive_interaction_mask)
-    positive_predictions = tf.gather_nd(tf_prediction, indices=positive_interaction_indices)
+    def loss_graph(self, tf_interactions, tf_prediction, **kwargs):
 
-    n_items = tf.cast(tf.shape(tf_prediction)[1], dtype=tf.float32)
-    predictions_sum_per_user = tf.reduce_sum(tf_prediction, axis=1)
-    mapped_predictions_sum_per_user = tf.gather(params=predictions_sum_per_user,
-                                                indices=tf.transpose(positive_interaction_indices)[0])
+        positive_interaction_mask = tf.greater(tf_interactions.values, 0.0)
+        positive_interaction_indices = tf.boolean_mask(tf_interactions.indices,
+                                                       positive_interaction_mask)
+        positive_predictions = tf.gather_nd(tf_prediction, indices=positive_interaction_indices)
 
-    # TODO smart irrelevant item indicator -- using n_items is an approximation for sparse interactions
-    irrelevant_item_indicator = n_items # noqa
+        n_items = tf.cast(tf.shape(tf_prediction)[1], dtype=tf.float32)
+        predictions_sum_per_user = tf.reduce_sum(tf_prediction, axis=1)
+        mapped_predictions_sum_per_user = tf.gather(params=predictions_sum_per_user,
+                                                    indices=tf.transpose(positive_interaction_indices)[0])
 
-    sampled_margin_rank = (n_items - (n_items * positive_predictions)
-                           + mapped_predictions_sum_per_user + irrelevant_item_indicator)
+        # TODO smart irrelevant item indicator -- using n_items is an approximation for sparse interactions
+        irrelevant_item_indicator = n_items # noqa
 
-    # JKirk - I am leaving out the log term due to experimental results
-    # loss = tf.log(sampled_margin_rank + 1.0)
-    return sampled_margin_rank
+        sampled_margin_rank = (n_items - (n_items * positive_predictions)
+                               + mapped_predictions_sum_per_user + irrelevant_item_indicator)
+
+        # JKirk - I am leaving out the log term due to experimental results
+        # loss = tf.log(sampled_margin_rank + 1.0)
+        return sampled_margin_rank
 
 
-def wmrb_alignment_loss(tf_interactions, tf_alignment, **kwargs):
+class WMRBAlignmentLoss(WMRBLoss):
     """
     Approximation of http://ceur-ws.org/Vol-1905/recsys2017_poster3.pdf
     Ranks items based on alignment, in place of prediction.
     Interactions can be any positive values, but magnitude is ignored. Negative interactions are also ignored.
-    :param tf_interactions:
-    :param tf_alignment:
-    :param kwargs:
-    :return:
     """
-    return wmrb_loss(tf_interactions=tf_interactions, tf_prediction=tf_alignment)
+    def __init__(self):
+        super(WMRBAlignmentLoss, self).__init__()
 
-
-def warp_loss(tf_prediction, tf_y, **kwargs):
-    # TODO JK: implement WARP loss
-
-    tf_positive_mask = tf.greater(tf_y, 0.0)
-    tf_negative_mask = tf.less_equal(tf_y, 0.0)
-
-    tf_positive_predictions = tf.boolean_mask(tf_prediction, tf_positive_mask) # noqa
-    tf_negative_predictions = tf.boolean_mask(tf_prediction, tf_negative_mask) # noqa
+    def loss_graph(self, tf_interactions, tf_alignment, **kwargs):
+        return super(WMRBAlignmentLoss, self).loss_graph(tf_interactions=tf_interactions, tf_prediction=tf_alignment)

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -32,7 +32,7 @@ class AbstractLossGraph(object):
         pass
 
 
-class RMSELoss(AbstractLossGraph):
+class RMSELossGraph(AbstractLossGraph):
     """
     This loss function returns the root mean square error between the predictions and the true interactions.
     Interactions can be any positive or negative values, and this loss function is sensitive to magnitude.
@@ -41,7 +41,7 @@ class RMSELoss(AbstractLossGraph):
         return tf.sqrt(tf.reduce_mean(tf.square(tf_interactions_serial - tf_prediction_serial)))
 
 
-class SeparationLoss(AbstractLossGraph):
+class SeparationLossGraph(AbstractLossGraph):
     """
     This loss function models the explicit positive and negative interaction predictions as normal distributions and
     returns the probability of overlap between the two distributions.
@@ -66,13 +66,13 @@ class SeparationLoss(AbstractLossGraph):
         return loss
 
 
-class WMRBLoss(AbstractLossGraph):
+class WMRBLossGraph(AbstractLossGraph):
     """
     Approximation of http://ceur-ws.org/Vol-1905/recsys2017_poster3.pdf
     Interactions can be any positive values, but magnitude is ignored. Negative interactions are also ignored.
     """
     def __init__(self):
-        super(WMRBLoss, self).__init__(is_dense=True)
+        super(WMRBLossGraph, self).__init__(is_dense=True)
 
     def loss_graph(self, tf_interactions, tf_prediction, **kwargs):
 
@@ -97,14 +97,15 @@ class WMRBLoss(AbstractLossGraph):
         return sampled_margin_rank
 
 
-class WMRBAlignmentLoss(WMRBLoss):
+class WMRBAlignmentLossGraph(WMRBLossGraph):
     """
     Approximation of http://ceur-ws.org/Vol-1905/recsys2017_poster3.pdf
     Ranks items based on alignment, in place of prediction.
     Interactions can be any positive values, but magnitude is ignored. Negative interactions are also ignored.
     """
     def __init__(self):
-        super(WMRBAlignmentLoss, self).__init__()
+        super(WMRBAlignmentLossGraph, self).__init__()
 
     def loss_graph(self, tf_interactions, tf_alignment, **kwargs):
-        return super(WMRBAlignmentLoss, self).loss_graph(tf_interactions=tf_interactions, tf_prediction=tf_alignment)
+        return super(WMRBAlignmentLossGraph, self).loss_graph(tf_interactions=tf_interactions,
+                                                              tf_prediction=tf_alignment)

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -12,14 +12,22 @@ class AbstractLossGraph(object):
     def loss_graph(self, tf_prediction_serial, tf_interactions_serial, tf_prediction, tf_interactions, tf_rankings,
                    tf_alignment):
         """
-        TODO document
-        :param tf_prediction_serial:
-        :param tf_interactions_serial:
-        :param tf_prediction:
-        :param tf_interactions:
-        :param tf_rankings:
-        :param tf_alignment:
-        :return:
+        This method is responsible for consuming a number of possible nodes from the graph and calculating loss from
+        those nodes.
+        :param tf_prediction_serial: tf.Tensor
+        The recommendation scores as a Tensor of shape [n_samples, 1]
+        :param tf_interactions_serial: tf.Tensor
+        The sample interactions corresponding to tf_prediction_serial as a Tensor of shape [n_samples, 1]
+        :param tf_prediction: tf.Tensor
+        The recommendation scores as a Tensor of shape [n_users, n_items]
+        :param tf_interactions: tf.SparseTensor
+        The sample interactions as a SparseTensor of shape [n_users, n_items]
+        :param tf_rankings: tf.Tensor
+        The item ranks as a Tensor of shape [n_users, n_items]
+        :param tf_alignment: tf.Tensor
+        The item alignments as a Tensor of shape [n_users, n_items]
+        :return: tf.Tensor
+        The loss value.
         """
         pass
 

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -5,7 +5,7 @@ from scipy import sparse as sp
 import six
 import tensorflow as tf
 
-from .loss_graphs import AbstractLossGraph, RMSELoss
+from .loss_graphs import AbstractLossGraph, RMSELossGraph
 from .recommendation_graphs import (project_biases, prediction_dense, prediction_serial, split_sparse_tensor_indices,
                                     bias_prediction_dense, bias_prediction_serial, rank_predictions, alignment)
 from .representation_graphs import linear_representation_graph
@@ -17,7 +17,7 @@ class TensorRec(object):
     def __init__(self, n_components=100,
                  user_repr_graph=linear_representation_graph,
                  item_repr_graph=linear_representation_graph,
-                 loss_graph=RMSELoss(),
+                 loss_graph=RMSELossGraph(),
                  biased=True):
         """
         A TensorRec recommendation model.

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -1,5 +1,12 @@
+import numpy as np
 import random
 import scipy.sparse as sp
+
+
+def sample_items(n_items, n_sampled, n_users):
+    return np.array([
+        np.random.choice(a=n_items, size=n_sampled) for _ in range(n_users)
+    ])
 
 
 def generate_dummy_data(num_users=15000, num_items=30000, interaction_density=.00045, num_user_features=200,

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from tensorrec import TensorRec
-from tensorrec.loss_graphs import RMSELoss, SeparationLoss, WMRBLoss, WMRBAlignmentLoss
+from tensorrec.loss_graphs import RMSELossGraph, SeparationLossGraph, WMRBLossGraph, WMRBAlignmentLossGraph
 from tensorrec.util import generate_dummy_data_with_indicator
 
 
@@ -13,33 +13,33 @@ class LossGraphsTestCase(TestCase):
             num_users=10, num_items=12, interaction_density=.5)
 
     def test_rmse_loss(self):
-        model = TensorRec(loss_graph=RMSELoss())
+        model = TensorRec(loss_graph=RMSELossGraph())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_rmse_loss_biased(self):
-        model = TensorRec(loss_graph=RMSELoss(), biased=True)
+        model = TensorRec(loss_graph=RMSELossGraph(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss(self):
-        model = TensorRec(loss_graph=SeparationLoss())
+        model = TensorRec(loss_graph=SeparationLossGraph())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss_biased(self):
-        model = TensorRec(loss_graph=SeparationLoss(), biased=True)
+        model = TensorRec(loss_graph=SeparationLossGraph(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss(self):
-        model = TensorRec(loss_graph=WMRBLoss())
+        model = TensorRec(loss_graph=WMRBLossGraph())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss_biased(self):
-        model = TensorRec(loss_graph=WMRBLoss(), biased=True)
+        model = TensorRec(loss_graph=WMRBLossGraph(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss(self):
-        model = TensorRec(loss_graph=WMRBAlignmentLoss())
+        model = TensorRec(loss_graph=WMRBAlignmentLossGraph())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss_biased(self):
-        model = TensorRec(loss_graph=WMRBAlignmentLoss(), biased=True)
+        model = TensorRec(loss_graph=WMRBAlignmentLossGraph(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
 from tensorrec import TensorRec
-from tensorrec.loss_graphs import RMSELossGraph, SeparationLossGraph, WMRBLossGraph, WMRBAlignmentLossGraph
+from tensorrec.loss_graphs import (
+    RMSELossGraph, RMSEDenseLossGraph, SeparationLossGraph, WMRBLossGraph, WMRBAlignmentLossGraph
+)
 from tensorrec.util import generate_dummy_data_with_indicator
 
 
@@ -13,33 +15,41 @@ class LossGraphsTestCase(TestCase):
             num_users=10, num_items=12, interaction_density=.5)
 
     def test_rmse_loss(self):
-        model = TensorRec(loss_graph=RMSELossGraph())
+        model = TensorRec(loss_graph=RMSELossGraph)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_rmse_loss_biased(self):
-        model = TensorRec(loss_graph=RMSELossGraph(), biased=True)
+        model = TensorRec(loss_graph=RMSELossGraph, biased=True)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+
+    def test_rmse_loss(self):
+        model = TensorRec(loss_graph=RMSEDenseLossGraph)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+
+    def test_rmse_loss_biased(self):
+        model = TensorRec(loss_graph=RMSEDenseLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss(self):
-        model = TensorRec(loss_graph=SeparationLossGraph())
+        model = TensorRec(loss_graph=SeparationLossGraph)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss_biased(self):
-        model = TensorRec(loss_graph=SeparationLossGraph(), biased=True)
+        model = TensorRec(loss_graph=SeparationLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss(self):
-        model = TensorRec(loss_graph=WMRBLossGraph())
+        model = TensorRec(loss_graph=WMRBLossGraph)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss_biased(self):
-        model = TensorRec(loss_graph=WMRBLossGraph(), biased=True)
+        model = TensorRec(loss_graph=WMRBLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss(self):
-        model = TensorRec(loss_graph=WMRBAlignmentLossGraph())
+        model = TensorRec(loss_graph=WMRBAlignmentLossGraph)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss_biased(self):
-        model = TensorRec(loss_graph=WMRBAlignmentLossGraph(), biased=True)
+        model = TensorRec(loss_graph=WMRBAlignmentLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -22,11 +22,11 @@ class LossGraphsTestCase(TestCase):
         model = TensorRec(loss_graph=RMSELossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
-    def test_rmse_loss(self):
+    def test_rmse_dense_loss(self):
         model = TensorRec(loss_graph=RMSEDenseLossGraph)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
-    def test_rmse_loss_biased(self):
+    def test_rmse_dense_loss_biased(self):
         model = TensorRec(loss_graph=RMSEDenseLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from tensorrec import TensorRec
-from tensorrec.loss_graphs import rmse_loss, separation_loss, wmrb_loss, wmrb_alignment_loss
+from tensorrec.loss_graphs import RMSELoss, SeparationLoss, WMRBLoss, WMRBAlignmentLoss
 from tensorrec.util import generate_dummy_data_with_indicator
 
 
@@ -13,33 +13,33 @@ class LossGraphsTestCase(TestCase):
             num_users=10, num_items=12, interaction_density=.5)
 
     def test_rmse_loss(self):
-        model = TensorRec(loss_graph=rmse_loss)
+        model = TensorRec(loss_graph=RMSELoss())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_rmse_loss_biased(self):
-        model = TensorRec(loss_graph=rmse_loss, biased=True)
+        model = TensorRec(loss_graph=RMSELoss(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss(self):
-        model = TensorRec(loss_graph=separation_loss)
+        model = TensorRec(loss_graph=SeparationLoss())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_separation_loss_biased(self):
-        model = TensorRec(loss_graph=separation_loss, biased=True)
+        model = TensorRec(loss_graph=SeparationLoss(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss(self):
-        model = TensorRec(loss_graph=wmrb_loss)
+        model = TensorRec(loss_graph=WMRBLoss())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss_biased(self):
-        model = TensorRec(loss_graph=wmrb_loss, biased=True)
+        model = TensorRec(loss_graph=WMRBLoss(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss(self):
-        model = TensorRec(loss_graph=wmrb_alignment_loss)
+        model = TensorRec(loss_graph=WMRBAlignmentLoss())
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_alignment_loss_biased(self):
-        model = TensorRec(loss_graph=wmrb_alignment_loss, biased=True)
+        model = TensorRec(loss_graph=WMRBAlignmentLoss(), biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)

--- a/test/test_movielens.py
+++ b/test/test_movielens.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from tensorrec import TensorRec
-from tensorrec.loss_graphs import wmrb_loss
+from tensorrec.loss_graphs import WMRBLoss
 
 from test.datasets import get_movielens_100k
 
@@ -33,7 +33,7 @@ class MovieLensTestCase(TestCase):
         """
         train_interactions, test_interactions, user_features, item_features = self.movielens_100k
 
-        model = TensorRec(loss_graph=wmrb_loss)
+        model = TensorRec(loss_graph=WMRBLoss())
         model.fit(interactions=train_interactions, user_features=user_features, item_features=item_features)
         predictions = model.predict(user_features=user_features,
                                     item_features=item_features)

--- a/test/test_movielens.py
+++ b/test/test_movielens.py
@@ -33,7 +33,7 @@ class MovieLensTestCase(TestCase):
         """
         train_interactions, test_interactions, user_features, item_features = self.movielens_100k
 
-        model = TensorRec(loss_graph=WMRBLossGraph())
+        model = TensorRec(loss_graph=WMRBLossGraph)
         model.fit(interactions=train_interactions, user_features=user_features, item_features=item_features)
         predictions = model.predict(user_features=user_features,
                                     item_features=item_features)

--- a/test/test_movielens.py
+++ b/test/test_movielens.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from tensorrec import TensorRec
-from tensorrec.loss_graphs import WMRBLoss
+from tensorrec.loss_graphs import WMRBLossGraph
 
 from test.datasets import get_movielens_100k
 
@@ -33,7 +33,7 @@ class MovieLensTestCase(TestCase):
         """
         train_interactions, test_interactions, user_features, item_features = self.movielens_100k
 
-        model = TensorRec(loss_graph=WMRBLoss())
+        model = TensorRec(loss_graph=WMRBLossGraph())
         model.fit(interactions=train_interactions, user_features=user_features, item_features=item_features)
         predictions = model.predict(user_features=user_features,
                                     item_features=item_features)

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -96,7 +96,7 @@ class ReadmeTestCase(TestCase):
                 return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
         # Build a model with the custom loss function
-        model = tensorrec.TensorRec(loss_graph=SimpleLossGraph())
+        model = tensorrec.TensorRec(loss_graph=SimpleLossGraph)
 
         # Generate some dummy data
         interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -71,7 +71,7 @@ class ReadmeTestCase(TestCase):
         import tensorflow as tf
         import tensorrec
 
-        # Define a custom loss function graph
+        # Define a custom loss graph
         class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
             def loss_graph(self, tf_prediction, tf_y, **kwargs):
                 """

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -87,7 +87,7 @@ class ReadmeTestCase(TestCase):
                 :param tf_prediction_serial: tf.Tensor
                 The recommendation scores as a Tensor of shape [n_samples, 1]
                 :param tf_interactions_serial: tf.Tensor
-                The sample interactions corresponding to tf_prediction as a Tensor of shape [n_samples, 1]
+                The sample interactions corresponding to tf_prediction_serial as a Tensor of shape [n_samples, 1]
                 :param kwargs:
                 Other TensorFlow nodes.
                 :return:

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -80,7 +80,7 @@ class ReadmeTestCase(TestCase):
         import tensorrec
 
         # Define a custom loss graph
-        class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
+        class SimpleLossGraph(tensorrec.loss_graphs.AbstractLossGraph):
             def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
                 """
                 This loss function returns the absolute simple error between the predictions and the interactions.
@@ -96,7 +96,7 @@ class ReadmeTestCase(TestCase):
                 return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
         # Build a model with the custom loss function
-        model = tensorrec.TensorRec(loss_graph=SimpleLoss())
+        model = tensorrec.TensorRec(loss_graph=SimpleLossGraph())
 
         # Generate some dummy data
         interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -1,0 +1,93 @@
+from unittest import TestCase
+
+
+class ReadmeTestCase(TestCase):
+
+    def test_basic_usage(self):
+        import numpy as np
+        import tensorrec
+
+        # Build the model with default parameters
+        model = tensorrec.TensorRec()
+
+        # Generate some dummy data
+        interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,
+                                                                                        num_items=150,
+                                                                                        interaction_density=.05)
+
+        # Fit the model for 5 epochs
+        model.fit(interactions, user_features, item_features, epochs=5, verbose=True)
+
+        # Predict scores for all users and all items
+        predictions = model.predict(user_features=user_features,
+                                    item_features=item_features)
+
+        # Calculate and print the recall at 10
+        r_at_k = tensorrec.eval.recall_at_k(model, interactions,
+                                            k=10,
+                                            user_features=user_features,
+                                            item_features=item_features)
+        print(np.mean(r_at_k))
+
+        self.assertIsNotNone(predictions)
+
+    def test_custom_repr_graph(self):
+        import tensorflow as tf
+        import tensorrec
+
+        # Define a custom representation function graph
+        def tanh_representation_graph(tf_features, n_components, n_features, node_name_ending):
+            """
+            This representation function embeds the user/item features by passing them through a single tanh layer.
+            :param tf_features: tf.SparseTensor
+            The user/item features as a SparseTensor of dimensions [n_users/items, n_features]
+            :param n_components: int
+            The dimensionality of the resulting representation.
+            :param n_features: int
+            The number of features in tf_features
+            :param node_name_ending: String
+            Either 'user' or 'item'
+            :return:
+            A tuple of (tf.Tensor, list) where the first value is the resulting representation in n_components
+            dimensions and the second value is a list containing all tf.Variables which should be subject to
+            regularization.
+            """
+            tf_tanh_weights = tf.Variable(tf.random_normal([n_features, n_components],
+                                                           stddev=.5),
+                                          name='tanh_weights_%s' % node_name_ending)
+
+            tf_repr = tf.nn.tanh(tf.sparse_tensor_dense_matmul(tf_features, tf_tanh_weights))
+
+            # Return repr layer and variables
+            return tf_repr, [tf_tanh_weights]
+
+        # Build a model with the custom representation function
+        model = tensorrec.TensorRec(user_repr_graph=tanh_representation_graph,
+                                    item_repr_graph=tanh_representation_graph)
+
+        self.assertIsNotNone(model)
+
+    def test_custom_loss_graph(self):
+        import tensorflow as tf
+        import tensorrec
+
+        # Define a custom loss function graph
+        class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
+            def loss_graph(self, tf_prediction, tf_y, **kwargs):
+                """
+                This loss function returns the absolute simple error between the predictions and the interactions.
+                :param tf_prediction_serial: tf.Tensor
+                The recommendation scores as a Tensor of shape [n_samples, 1]
+                :param tf_interactions_serial: tf.Tensor
+                The sample interactions corresponding to tf_prediction as a Tensor of shape [n_samples, 1]
+                :param kwargs:
+                Other TensorFlow nodes.
+                :return:
+                A tf.Tensor containing the learning loss.
+                """
+                return tf.reduce_mean(tf.abs(tf_y - tf_prediction))
+
+        # Build a model with the custom loss function
+        model = tensorrec.TensorRec(loss_graph=SimpleLoss())
+
+        self.assertIsNotNone(model)

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -65,6 +65,14 @@ class ReadmeTestCase(TestCase):
         model = tensorrec.TensorRec(user_repr_graph=tanh_representation_graph,
                                     item_repr_graph=tanh_representation_graph)
 
+        # Generate some dummy data
+        interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,
+                                                                                        num_items=150,
+                                                                                        interaction_density=.05)
+
+        # Fit the model for 5 epochs
+        model.fit(interactions, user_features, item_features, epochs=5, verbose=True)
+
         self.assertIsNotNone(model)
 
     def test_custom_loss_graph(self):
@@ -73,7 +81,7 @@ class ReadmeTestCase(TestCase):
 
         # Define a custom loss graph
         class SimpleLoss(tensorrec.loss_graphs.AbstractLossGraph):
-            def loss_graph(self, tf_prediction, tf_y, **kwargs):
+            def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
                 """
                 This loss function returns the absolute simple error between the predictions and the interactions.
                 :param tf_prediction_serial: tf.Tensor
@@ -85,9 +93,17 @@ class ReadmeTestCase(TestCase):
                 :return:
                 A tf.Tensor containing the learning loss.
                 """
-                return tf.reduce_mean(tf.abs(tf_y - tf_prediction))
+                return tf.reduce_mean(tf.abs(tf_interactions_serial - tf_prediction_serial))
 
         # Build a model with the custom loss function
         model = tensorrec.TensorRec(loss_graph=SimpleLoss())
+
+        # Generate some dummy data
+        interactions, user_features, item_features = tensorrec.util.generate_dummy_data(num_users=100,
+                                                                                        num_items=150,
+                                                                                        interaction_density=.05)
+
+        # Fit the model for 5 epochs
+        model.fit(interactions, user_features, item_features, epochs=5, verbose=True)
 
         self.assertIsNotNone(model)

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -1,3 +1,4 @@
+import numpy as np
 import shutil
 import tempfile
 from unittest import TestCase
@@ -35,6 +36,10 @@ class TensorRecTestCase(TestCase):
             TensorRec(item_repr_graph=None)
         with self.assertRaises(ValueError):
             TensorRec(loss_graph=None)
+
+    def test_init_fail_bad_loss_graph(self):
+        with self.assertRaises(ValueError):
+            TensorRec(loss_graph=np.mean)
 
     def test_fit(self):
         # Ensure that the nodes have been built


### PR DESCRIPTION
This one's a doozy, and lays the groundwork for loss functions with random sampling.

1. Changes loss_graph top level API to take in AbstractLossGraph objects.
2. Modifies all implemented loss graphs to inherit AbstractLossGraph.
3. Modifies graph construction to only pass serial nodes to loss function when loss function isn't dense for safety.
4. Updates README to show AbstractLossGraph example.
5. Moves readme test cases to their own module to test imports inside the unit tests.
6. Adds item sampler stub (this was intended for a later PR, but whoops).
7. Adds RMSEDenseLossGraph -- a version of RMSE that treats items with no interaction as interactions of value `0`.