### PR TITLE
ENH: Adds random sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import tensorrec
 
 # Define a custom loss graph
 class SimpleLossGraph(tensorrec.loss_graphs.AbstractLossGraph):
-    def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
+    def connect_loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
         """
         This loss function returns the absolute simple error between the predictions and the interactions.
         :param tf_prediction_serial: tf.Tensor

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -8,6 +8,9 @@ class AbstractLossGraph(object):
     # Parameters for loss usage
     is_dense = False
 
+    # Parameter for item sampling in loss
+    is_random_sample_based = False
+
     @abc.abstractmethod
     def loss_graph(self, tf_prediction_serial, tf_interactions_serial, tf_prediction, tf_interactions, tf_rankings,
                    tf_alignment):
@@ -85,6 +88,7 @@ class WMRBLossGraph(AbstractLossGraph):
     Interactions can be any positive values, but magnitude is ignored. Negative interactions are also ignored.
     """
     is_dense = True
+    is_random_sample_based = True
 
     def loss_graph(self, tf_interactions, tf_prediction, **kwargs):
 

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -67,8 +67,8 @@ class SeparationLossGraph(AbstractLossGraph):
     """
     This loss function models the explicit positive and negative interaction predictions as normal distributions and
     returns the probability of overlap between the two distributions.
-    Interactions can be any positive or negative values, but this loss function ignored the magnitude of the
-    interaction -- interactions are grouped in to {i < 0} and {i > 0}.
+    Interactions can be any positive or negative values, but this loss function ignores the magnitude of the
+    interaction -- interactions are grouped in to {i <= 0} and {i > 0}.
     """
     def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
 
@@ -91,9 +91,10 @@ class SeparationLossGraph(AbstractLossGraph):
 class SeparationDenseLossGraph(AbstractLossGraph):
     """
     This loss function models all positive and negative interaction predictions as normal distributions and
-    returns the probability of overlap between the two distributions.
-    Interactions can be any positive or negative values, but this loss function ignored the magnitude of the
-    interaction -- interactions are grouped in to {i < 0} and {i > 0}.
+    returns the probability of overlap between the two distributions. This loss function includes non-interacted items
+    as negative interactions.
+    Interactions can be any positive or negative values, but this loss function ignores the magnitude of the
+    interaction -- interactions are grouped in to {i <= 0} and {i > 0}.
     """
     is_dense = True
 
@@ -179,7 +180,7 @@ class WMRBAlignmentLossGraph(WMRBLossGraph):
         # WMRB expects bounded predictions
         normed_alignment = .5 * (tf_alignment + 1.0)
         normed_sample_alignments = .5 * (tf_sample_alignments + 1.0)
-        
+
         return self.weighted_margin_rank_batch(tf_prediction=normed_alignment,
                                                tf_interactions=tf_interactions,
                                                tf_sample_predictions=normed_sample_alignments)

--- a/tensorrec/loss_graphs.py
+++ b/tensorrec/loss_graphs.py
@@ -134,12 +134,12 @@ class WMRBLossGraph(AbstractLossGraph):
     def loss_graph(self, tf_prediction, tf_interactions, tf_sample_predictions, **kwargs):
 
         # WMRB expects bounded predictions
-        tanh_prediction = tf.nn.sigmoid(tf_prediction)
-        tanh_sample_prediction = tf.nn.sigmoid(tf_sample_predictions)
+        bounded_prediction = tf.nn.sigmoid(tf_prediction)
+        bounded_sample_prediction = tf.nn.sigmoid(tf_sample_predictions)
 
-        return self.weighted_margin_rank_batch(tf_prediction=tanh_prediction,
+        return self.weighted_margin_rank_batch(tf_prediction=bounded_prediction,
                                                tf_interactions=tf_interactions,
-                                               tf_sample_predictions=tanh_sample_prediction)
+                                               tf_sample_predictions=bounded_sample_prediction)
 
     @classmethod
     def weighted_margin_rank_batch(cls, tf_prediction, tf_interactions, tf_sample_predictions):

--- a/tensorrec/recommendation_graphs.py
+++ b/tensorrec/recommendation_graphs.py
@@ -94,6 +94,24 @@ def bias_prediction_serial(tf_prediction_serial, tf_projected_user_biases, tf_pr
     return tf_prediction_serial + gathered_user_biases + gathered_item_biases
 
 
+def gather_sampled_item_predictions(tf_prediction, tf_sampled_item_indices):
+    """
+    Gathers the predictions for the given sampled items.
+    :param tf_prediction:
+    :param tf_sampled_item_indices:
+    :return:
+    """
+    prediction_shape = tf.shape(tf_prediction)
+    flattened_prediction = tf.reshape(tf_prediction, shape=[prediction_shape[0] * prediction_shape[1]])
+
+    indices_shape = tf.shape(tf_sampled_item_indices)
+    flattened_indices = tf.reshape(tf_sampled_item_indices, shape=[indices_shape[0] * indices_shape[1]])
+
+    gathered_predictions = tf.gather(params=flattened_prediction, indices=flattened_indices)
+    reshaped_gathered_predictions = tf.reshape(gathered_predictions, shape=indices_shape)
+    return reshaped_gathered_predictions
+
+
 def rank_predictions(tf_prediction):
     """
     Double-sortation serves as a ranking process

--- a/tensorrec/recommendation_graphs.py
+++ b/tensorrec/recommendation_graphs.py
@@ -62,8 +62,8 @@ def alignment(tf_user_representation, tf_item_representation):
     :param tf_item_representation:
     :return:
     """
-    normalized_users = tf.nn.l2_normalize(tf_user_representation, 0)
-    normalized_items = tf.nn.l2_normalize(tf_item_representation, 0)
+    normalized_users = tf.nn.l2_normalize(tf_user_representation, 1)
+    normalized_items = tf.nn.l2_normalize(tf_item_representation, 1)
     return tf.matmul(normalized_users, normalized_items, transpose_b=True)
 
 

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -316,7 +316,7 @@ class TensorRec(object):
                                       'tf_sample_alignments': tf_sample_alignments})
 
         # Build loss graph
-        self.tf_basic_loss = self.loss_graph().loss_graph(**loss_graph_kwargs)
+        self.tf_basic_loss = self.loss_graph().connect_loss_graph(**loss_graph_kwargs)
 
         self.tf_weight_reg_loss = sum(tf.nn.l2_loss(weights) for weights in tf_weights)
         self.tf_loss = self.tf_basic_loss + (self.tf_alpha * self.tf_weight_reg_loss)

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -11,6 +11,7 @@ from .recommendation_graphs import (project_biases, prediction_dense, prediction
                                     bias_prediction_dense, bias_prediction_serial, rank_predictions, alignment)
 from .representation_graphs import linear_representation_graph
 from .session_management import get_session
+from .util import sample_items
 
 
 class TensorRec(object):
@@ -50,7 +51,7 @@ class TensorRec(object):
         self.n_components = n_components
         self.user_repr_graph_factory = user_repr_graph
         self.item_repr_graph_factory = item_repr_graph
-        self.loss_graph_factory = loss_graph
+        self.loss_graph = loss_graph
         self.biased = biased
 
         # A list of the attr names of every graph hook attr
@@ -66,6 +67,7 @@ class TensorRec(object):
             # Feed placeholders
             'tf_n_users', 'tf_n_items', 'tf_user_feature_indices', 'tf_user_feature_values', 'tf_item_feature_indices',
             'tf_item_feature_values', 'tf_interaction_indices', 'tf_interaction_values', 'tf_learning_rate', 'tf_alpha',
+            'tf_sampled_item_indices'
         ]
         self.graph_operation_hook_attr_names = [
             # AdamOptimizer
@@ -221,6 +223,7 @@ class TensorRec(object):
         self.tf_interaction_values = tf.placeholder('float', [None])
         self.tf_learning_rate = tf.placeholder('float', None)
         self.tf_alpha = tf.placeholder('float', None)
+        self.tf_sampled_item_indices = tf.placeholder('int64', [None, None])
 
         # Construct the features and interactions as sparse matrices
         tf_user_features = tf.SparseTensor(self.tf_user_feature_indices, self.tf_user_feature_values,
@@ -294,7 +297,7 @@ class TensorRec(object):
             'tf_prediction_serial': self.tf_prediction_serial,
             'tf_interactions_serial': tf_interactions_serial,
         }
-        if self.loss_graph_factory.is_dense:
+        if self.loss_graph.is_dense:
             loss_graph_kwargs.update({
                 'tf_prediction': self.tf_prediction,
                 'tf_interactions': tf_interactions,
@@ -303,7 +306,7 @@ class TensorRec(object):
             })
 
         # Build loss graph
-        self.tf_basic_loss = self.loss_graph_factory().loss_graph(**loss_graph_kwargs)
+        self.tf_basic_loss = self.loss_graph().loss_graph(**loss_graph_kwargs)
 
         self.tf_weight_reg_loss = sum(tf.nn.l2_loss(weights) for weights in tf_weights)
         self.tf_loss = self.tf_basic_loss + (self.tf_alpha * self.tf_weight_reg_loss)
@@ -318,7 +321,7 @@ class TensorRec(object):
             self.graph_operation_hook_node_names[graph_operation_hook_attr_name] = hook.name
 
     def fit(self, interactions, user_features, item_features, epochs=100, learning_rate=0.1, alpha=0.00001,
-            verbose=False, out_sample_interactions=None, user_batch_size=None):
+            verbose=False, out_sample_interactions=None, user_batch_size=None, n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
         :param interactions: scipy.sparse matrix
@@ -340,6 +343,9 @@ class TensorRec(object):
         If not None, and verbose == True, the model will be evaluated on these interactions on every epoch.
         :param user_batch_size: int or None
         The maximum number of users per batch, or None for all users.
+        :param n_sampled_items: int or None
+        The number of items to sample per user for use in loss functions. Must be non-None if
+        self.loss_graph.is_random_sample_based is True.
         """
 
         # Pass-through to fit_partial
@@ -351,10 +357,12 @@ class TensorRec(object):
                          alpha=alpha,
                          verbose=verbose,
                          out_sample_interactions=out_sample_interactions,
-                         user_batch_size=user_batch_size)
+                         user_batch_size=user_batch_size,
+                         n_sampled_items=n_sampled_items)
 
     def fit_partial(self, interactions, user_features, item_features, epochs=1, learning_rate=0.1,
-                    alpha=0.00001, verbose=False, out_sample_interactions=None, user_batch_size=None):
+                    alpha=0.00001, verbose=False, out_sample_interactions=None, user_batch_size=None,
+                    n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
         :param interactions: scipy.sparse matrix
@@ -376,9 +384,17 @@ class TensorRec(object):
         If not None, and verbose == True, the model will be evaluated on these interactions on every epoch.
         :param user_batch_size: int or None
         The maximum number of users per batch, or None for all users.
+        :param n_sampled_items: int or None
+        The number of items to sample per user for use in loss functions. Must be non-None if
+        self.loss_graph.is_random_sample_based is True.
         """
 
         session = get_session()
+
+        # Arg checking
+        if self.loss_graph.is_random_sample_based:
+            if (n_sampled_items is None) or (n_sampled_items <= 0):
+                raise ValueError("n_sampled_items must be an integer >0")
 
         # Check if the graph has been constructed by checking the dense prediction node
         # If it hasn't been constructed, initialize it
@@ -403,6 +419,13 @@ class TensorRec(object):
 
         for epoch in range(epochs):
             for batch, feed_dict in enumerate(batched_feed_dicts):
+
+                # Handle random item sampling, if applicable
+                if self.loss_graph.is_random_sample_based:
+                    sampled_item_indices = sample_items(n_users=feed_dict[self.tf_n_users],
+                                                        n_items=feed_dict[self.tf_n_items],
+                                                        n_sampled_items=n_sampled_items)
+                    feed_dict[self.tf_sampled_item_indices] = sampled_item_indices
 
                 # TODO find something more elegant than these cascaded ifs
                 if not verbose:

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -434,7 +434,8 @@ class TensorRec(object):
                 if self.loss_graph.is_sample_based:
                     sampled_item_indices = sample_items(n_users=feed_dict[self.tf_n_users],
                                                         n_items=feed_dict[self.tf_n_items],
-                                                        n_sampled_items=n_sampled_items)
+                                                        n_sampled_items=n_sampled_items,
+                                                        replace=self.loss_graph.is_sampled_with_replacement)
                     feed_dict[self.tf_sampled_item_indices] = sampled_item_indices
 
                 # TODO find something more elegant than these cascaded ifs

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -8,7 +8,8 @@ import tensorflow as tf
 
 from .loss_graphs import AbstractLossGraph, RMSELossGraph
 from .recommendation_graphs import (project_biases, prediction_dense, prediction_serial, split_sparse_tensor_indices,
-                                    bias_prediction_dense, bias_prediction_serial, rank_predictions, alignment)
+                                    bias_prediction_dense, bias_prediction_serial, rank_predictions, alignment,
+                                    gather_sampled_item_predictions)
 from .representation_graphs import linear_representation_graph
 from .session_management import get_session
 from .util import sample_items
@@ -304,6 +305,15 @@ class TensorRec(object):
                 'tf_rankings': self.tf_rankings,
                 'tf_alignment': self.tf_alignment,
             })
+        if self.loss_graph.is_random_sample_based:
+            tf_random_sample_predictions = gather_sampled_item_predictions(
+                tf_prediction=self.tf_prediction, tf_sampled_item_indices=self.tf_sampled_item_indices
+            )
+            tf_random_sample_alignments = gather_sampled_item_predictions(
+                tf_prediction=self.tf_alignment, tf_sampled_item_indices=self.tf_sampled_item_indices
+            )
+            loss_graph_kwargs.update({'tf_random_sample_predictions': tf_random_sample_predictions,
+                                      'tf_random_sample_alignments': tf_random_sample_alignments})
 
         # Build loss graph
         self.tf_basic_loss = self.loss_graph().loss_graph(**loss_graph_kwargs)

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -305,15 +305,15 @@ class TensorRec(object):
                 'tf_rankings': self.tf_rankings,
                 'tf_alignment': self.tf_alignment,
             })
-        if self.loss_graph.is_random_sample_based:
-            tf_random_sample_predictions = gather_sampled_item_predictions(
+        if self.loss_graph.is_sample_based:
+            tf_sample_predictions = gather_sampled_item_predictions(
                 tf_prediction=self.tf_prediction, tf_sampled_item_indices=self.tf_sampled_item_indices
             )
-            tf_random_sample_alignments = gather_sampled_item_predictions(
+            tf_sample_alignments = gather_sampled_item_predictions(
                 tf_prediction=self.tf_alignment, tf_sampled_item_indices=self.tf_sampled_item_indices
             )
-            loss_graph_kwargs.update({'tf_random_sample_predictions': tf_random_sample_predictions,
-                                      'tf_random_sample_alignments': tf_random_sample_alignments})
+            loss_graph_kwargs.update({'tf_sample_predictions': tf_sample_predictions,
+                                      'tf_sample_alignments': tf_sample_alignments})
 
         # Build loss graph
         self.tf_basic_loss = self.loss_graph().loss_graph(**loss_graph_kwargs)
@@ -355,7 +355,7 @@ class TensorRec(object):
         The maximum number of users per batch, or None for all users.
         :param n_sampled_items: int or None
         The number of items to sample per user for use in loss functions. Must be non-None if
-        self.loss_graph.is_random_sample_based is True.
+        self.loss_graph.is_sample_based is True.
         """
 
         # Pass-through to fit_partial
@@ -396,13 +396,13 @@ class TensorRec(object):
         The maximum number of users per batch, or None for all users.
         :param n_sampled_items: int or None
         The number of items to sample per user for use in loss functions. Must be non-None if
-        self.loss_graph.is_random_sample_based is True.
+        self.loss_graph.is_sample_based is True.
         """
 
         session = get_session()
 
         # Arg checking
-        if self.loss_graph.is_random_sample_based:
+        if self.loss_graph.is_sample_based:
             if (n_sampled_items is None) or (n_sampled_items <= 0):
                 raise ValueError("n_sampled_items must be an integer >0")
 
@@ -431,7 +431,7 @@ class TensorRec(object):
             for batch, feed_dict in enumerate(batched_feed_dicts):
 
                 # Handle random item sampling, if applicable
-                if self.loss_graph.is_random_sample_based:
+                if self.loss_graph.is_sample_based:
                     sampled_item_indices = sample_items(n_users=feed_dict[self.tf_n_users],
                                                         n_items=feed_dict[self.tf_n_items],
                                                         n_sampled_items=n_sampled_items)

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -3,9 +3,9 @@ import random
 import scipy.sparse as sp
 
 
-def sample_items(n_items, n_users, n_sampled_items):
+def sample_items(n_items, n_users, n_sampled_items, replace):
     return np.array([
-        np.random.choice(a=n_items, size=n_sampled_items) + (user_count * n_users)
+        np.random.choice(a=n_items, size=n_sampled_items, replace=replace) + (user_count * n_users)
         for user_count in range(n_users)
     ])
 

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -3,9 +3,9 @@ import random
 import scipy.sparse as sp
 
 
-def sample_items(n_items, n_sampled, n_users):
+def sample_items(n_items, n_users, n_sampled_items):
     return np.array([
-        np.random.choice(a=n_items, size=n_sampled) for _ in range(n_users)
+        np.random.choice(a=n_items, size=n_sampled_items) for _ in range(n_users)
     ])
 
 

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -5,7 +5,8 @@ import scipy.sparse as sp
 
 def sample_items(n_items, n_users, n_sampled_items):
     return np.array([
-        np.random.choice(a=n_items, size=n_sampled_items) for _ in range(n_users)
+        np.random.choice(a=n_items, size=n_sampled_items) + (user_count * n_users)
+        for user_count in range(n_users)
     ])
 
 

--- a/test/datasets.py
+++ b/test/datasets.py
@@ -4,11 +4,12 @@ import scipy.sparse as sp
 from lightfm import datasets
 
 
-def get_movielens_100k(min_positive_score=4):
+def get_movielens_100k(min_positive_score=4, negative_value=0):
     movielens_100k_dict = datasets.fetch_movielens(indicator_features=True, genre_features=True)
 
     def flip_ratings(ratings_matrix):
-        ratings_matrix.data = np.array([1 if rating >= min_positive_score else -1 for rating in ratings_matrix.data])
+        ratings_matrix.data = np.array([1 if rating >= min_positive_score else negative_value
+                                        for rating in ratings_matrix.data])
         return ratings_matrix
 
     test_interactions = flip_ratings(movielens_100k_dict['test'])

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -40,16 +40,16 @@ class LossGraphsTestCase(TestCase):
 
     def test_wmrb_loss(self):
         model = TensorRec(loss_graph=WMRBLossGraph)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5, n_sampled_items=10)
 
     def test_wmrb_loss_biased(self):
         model = TensorRec(loss_graph=WMRBLossGraph, biased=True)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5, n_sampled_items=10)
 
     def test_wmrb_alignment_loss(self):
         model = TensorRec(loss_graph=WMRBAlignmentLossGraph)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5, n_sampled_items=10)
 
     def test_wmrb_alignment_loss_biased(self):
         model = TensorRec(loss_graph=WMRBAlignmentLossGraph, biased=True)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
+        model.fit(self.interactions, self.user_features, self.item_features, epochs=5, n_sampled_items=10)

--- a/test/test_loss_graphs.py
+++ b/test/test_loss_graphs.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from tensorrec import TensorRec
 from tensorrec.loss_graphs import (
-    RMSELossGraph, RMSEDenseLossGraph, SeparationLossGraph, WMRBLossGraph, WMRBAlignmentLossGraph
+    RMSELossGraph, RMSEDenseLossGraph, WMRBLossGraph, WMRBAlignmentLossGraph
 )
 from tensorrec.util import generate_dummy_data_with_indicator
 
@@ -28,14 +28,6 @@ class LossGraphsTestCase(TestCase):
 
     def test_rmse_dense_loss_biased(self):
         model = TensorRec(loss_graph=RMSEDenseLossGraph, biased=True)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
-
-    def test_separation_loss(self):
-        model = TensorRec(loss_graph=SeparationLossGraph)
-        model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
-
-    def test_separation_loss_biased(self):
-        model = TensorRec(loss_graph=SeparationLossGraph, biased=True)
         model.fit(self.interactions, self.user_features, self.item_features, epochs=5)
 
     def test_wmrb_loss(self):

--- a/test/test_movielens.py
+++ b/test/test_movielens.py
@@ -34,7 +34,10 @@ class MovieLensTestCase(TestCase):
         train_interactions, test_interactions, user_features, item_features = self.movielens_100k
 
         model = TensorRec(loss_graph=WMRBLossGraph)
-        model.fit(interactions=train_interactions, user_features=user_features, item_features=item_features)
+        model.fit(interactions=train_interactions,
+                  user_features=user_features,
+                  item_features=item_features,
+                  n_sampled_items=10)
         predictions = model.predict(user_features=user_features,
                                     item_features=item_features)
 

--- a/test/test_readme.py
+++ b/test/test_readme.py
@@ -81,7 +81,7 @@ class ReadmeTestCase(TestCase):
 
         # Define a custom loss graph
         class SimpleLossGraph(tensorrec.loss_graphs.AbstractLossGraph):
-            def loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
+            def connect_loss_graph(self, tf_prediction_serial, tf_interactions_serial, **kwargs):
                 """
                 This loss function returns the absolute simple error between the predictions and the interactions.
                 :param tf_prediction_serial: tf.Tensor

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -1,0 +1,34 @@
+import numpy as np
+import tensorflow as tf
+from unittest import TestCase
+
+from tensorrec.recommendation_graphs import *
+from tensorrec.session_management import get_session
+
+
+class RecommendationGraphsTestCase(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = get_session()
+
+    def test_gather_sampled_item_predictions(self):
+        input_data = np.array([
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12]
+        ])
+        sample_indices = np.array([
+            [0, 3],  # Corresponds to [1, 4]
+            [5, 6],  # Corresponds to [6, 7]
+            [8, 8],  # Corresponds to [9, 9]
+        ])
+        result = gather_sampled_item_predictions(tf_prediction=tf.identity(input_data),
+                                                 tf_sampled_item_indices=tf.identity(sample_indices)).eval(session=self.session)
+
+        expected_result = np.array([
+            [1, 4],
+            [6, 7],
+            [9, 9],
+        ])
+        self.assertTrue((result == expected_result).all())

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -2,7 +2,7 @@ import numpy as np
 import tensorflow as tf
 from unittest import TestCase
 
-from tensorrec.recommendation_graphs import *
+from tensorrec.recommendation_graphs import gather_sampled_item_predictions, alignment
 from tensorrec.session_management import get_session
 
 
@@ -23,8 +23,9 @@ class RecommendationGraphsTestCase(TestCase):
             [5, 6],  # Corresponds to [6, 7]
             [8, 8],  # Corresponds to [9, 9]
         ])
-        result = gather_sampled_item_predictions(tf_prediction=tf.identity(input_data),
-                                                 tf_sampled_item_indices=tf.identity(sample_indices)).eval(session=self.session)
+        result = gather_sampled_item_predictions(
+            tf_prediction=tf.identity(input_data), tf_sampled_item_indices=tf.identity(sample_indices)
+        ).eval(session=self.session)
 
         expected_result = np.array([
             [1, 4],

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -32,3 +32,23 @@ class RecommendationGraphsTestCase(TestCase):
             [9, 9],
         ])
         self.assertTrue((result == expected_result).all())
+
+    def test_alignment(self):
+        array_1 = np.array([
+            [1.0, 1.0],
+            [10.0, 10.0],
+            [-1.0, 1.0],
+        ])
+        array_2 = np.array([
+            [1.0, 1.0],
+            [-1.0, -1.0],
+            [-1.0, 1.0],
+        ])
+        result = alignment(tf_user_representation=array_1, tf_item_representation=array_2).eval(session=self.session)
+
+        expected_result = np.array([
+            [1.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [0.0, 0.0, 1.0]
+        ])
+        self.assertTrue(np.allclose(result, expected_result))


### PR DESCRIPTION
1. Adds `is_sample_based` parameter to loss graphs.
2. Adds logic to generate random sample indices per batch during fitting.
3. Adds logic to gather the predictions from the randomly sampled items for loss.
4. Adds random sample logic to WMRB losses.
5. Adds test for the random sample gathering.
6. Fixes WMRB logic.
7. Removes SeparationLossGraph.
8. Various small refactors.