### PR TITLE
API: Exposing User & Item Biases

### DIFF
--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -644,12 +644,16 @@ class TensorRec(object):
 
     def predict_user_bias(self, user_features):
         # TODO: docstring
+        if not self.biased:
+            raise NotImplementedError('Cannot predict user bias for unbiased model')
         feed_dict = self._create_user_feed_dict(user_features_matrix=user_features)
         predictions = self.tf_projected_user_biases.eval(session=get_session(), feed_dict=feed_dict)
         return predictions
 
     def predict_item_bias(self, item_features):
         # TODO: docstring
+        if not self.biased:
+            raise NotImplementedError('Cannot predict item bias for unbiased model')
         feed_dict = self._create_item_feed_dict(item_features_matrix=item_features)
         predictions = self.tf_projected_item_biases.eval(session=get_session(), feed_dict=feed_dict)
         return predictions

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -78,6 +78,7 @@ class TensorRec(object):
             # Top-level API nodes
             'tf_user_representation', 'tf_item_representation', 'tf_prediction_serial', 'tf_prediction', 'tf_rankings',
             'tf_predict_dot_product', 'tf_predict_cosine_similarity', 'tf_predict_euclidian_similarity',
+            'tf_projected_user_biases', 'tf_projected_item_biases',
 
             # Training nodes
             'tf_basic_loss', 'tf_weight_reg_loss', 'tf_loss',
@@ -86,9 +87,6 @@ class TensorRec(object):
             'tf_n_users', 'tf_n_items', 'tf_user_feature_indices', 'tf_user_feature_values', 'tf_item_feature_indices',
             'tf_item_feature_values', 'tf_interaction_indices', 'tf_interaction_values', 'tf_learning_rate', 'tf_alpha',
             'tf_sample_indices', 'tf_n_sampled_items'
-        ]
-        self.biased_graph_tensor_hook_attr_names = [
-            'tf_projected_user_biases', 'tf_projected_item_biases',
         ]
         self.graph_operation_hook_attr_names = [
 
@@ -101,7 +99,6 @@ class TensorRec(object):
         # A map of every graph hook attr name to the node name after construction
         # Tensors and operations are stored separated because they are handled differently by TensorFlow
         self.graph_tensor_hook_node_names = {}
-        self.biased_graph_tensor_hook_node_names = {}
         self.graph_operation_hook_node_names = {}
 
     def _clear_graph_hook_attrs(self):
@@ -109,9 +106,6 @@ class TensorRec(object):
             self.__setattr__(graph_tensor_hook_attr_name, None)
         for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
             self.__setattr__(graph_operation_hook_attr_name, None)
-        if self.biased:
-            for biased_graph_tensor_hook_attr_name in self.biased_graph_tensor_hook_attr_names:
-                self.__setattr__(biased_graph_tensor_hook_attr_name, None)
 
     def _attach_graph_hook_attrs(self):
         session = get_session()
@@ -125,13 +119,6 @@ class TensorRec(object):
             graph_operation_hook_node_name = self.graph_operation_hook_node_names[graph_operation_hook_attr_name]
             node = session.graph.get_operation_by_name(name=graph_operation_hook_node_name)
             self.__setattr__(graph_operation_hook_attr_name, node)
-
-        if self.biased:
-            for biased_graph_tensor_hook_attr_name in self.biased_graph_tensor_hook_attr_names:
-                biased_graph_tensor_hook_node_name = self.biased_graph_tensor_hook_node_names[
-                    biased_graph_tensor_hook_attr_name]
-                node = session.graph.get_tensor_by_name(name=biased_graph_tensor_hook_node_name)
-                self.__setattr__(biased_graph_tensor_hook_attr_name, node)
 
     def _create_feed_dict(self, interactions_matrix, user_features_matrix, item_features_matrix,
                           extra_feed_kwargs=None):
@@ -404,14 +391,11 @@ class TensorRec(object):
         # Get node names for each graph hook
         for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
             hook = self.__getattribute__(graph_tensor_hook_attr_name)
-            self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
+            if hook is not None:
+                self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
         for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
             hook = self.__getattribute__(graph_operation_hook_attr_name)
             self.graph_operation_hook_node_names[graph_operation_hook_attr_name] = hook.name
-        if self.biased:
-            for biased_graph_tensor_hook_attr_name in self.biased_graph_tensor_hook_attr_names:
-                hook = self.__getattribute__(biased_graph_tensor_hook_attr_name)
-                self.biased_graph_tensor_hook_node_names[biased_graph_tensor_hook_attr_name] = hook.name
 
     def fit(self, interactions, user_features, item_features, epochs=100, learning_rate=0.1, alpha=0.00001,
             verbose=False, out_sample_interactions=None, user_batch_size=None, n_sampled_items=None):

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -78,7 +78,6 @@ class TensorRec(object):
             # Top-level API nodes
             'tf_user_representation', 'tf_item_representation', 'tf_prediction_serial', 'tf_prediction', 'tf_rankings',
             'tf_predict_dot_product', 'tf_predict_cosine_similarity', 'tf_predict_euclidian_similarity',
-            'tf_projected_user_biases', 'tf_projected_item_biases',
 
             # Training nodes
             'tf_basic_loss', 'tf_weight_reg_loss', 'tf_loss',
@@ -88,6 +87,10 @@ class TensorRec(object):
             'tf_item_feature_values', 'tf_interaction_indices', 'tf_interaction_values', 'tf_learning_rate', 'tf_alpha',
             'tf_sample_indices', 'tf_n_sampled_items'
         ]
+        if self.biased:
+            self.graph_tensor_hook_attr_names += [
+                'tf_projected_user_biases', 'tf_projected_item_biases',
+            ]
         self.graph_operation_hook_attr_names = [
 
             # AdamOptimizer
@@ -391,8 +394,7 @@ class TensorRec(object):
         # Get node names for each graph hook
         for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
             hook = self.__getattribute__(graph_tensor_hook_attr_name)
-            if hook is not None:
-                self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
+            self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
         for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
             hook = self.__getattribute__(graph_operation_hook_attr_name)
             self.graph_operation_hook_node_names[graph_operation_hook_attr_name] = hook.name

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -115,6 +115,18 @@ class TensorRecTestCase(TestCase):
         item_repr = self.unbiased_model.predict_item_representation(self.item_features)
         self.assertEqual(item_repr.shape, (self.item_features.shape[0], 10))
 
+    def test_predict_user_bias_unbiased_model(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.unbiased_model.predict_user_bias,
+            self.user_features)
+
+    def test_predict_item_bias_unbiased_model(self):
+        self.assertRaises(
+            NotImplementedError,
+            self.unbiased_model.predict_item_bias,
+            self.item_features)
+
     def test_predict_user_bias(self):
         user_bias = self.standard_model.predict_user_bias(self.user_features)
         print(user_bias)  # TODO what are expected values?

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -128,7 +128,8 @@ class TensorRecTestCase(TestCase):
             self.item_features)
 
 
-class TensorRecMovielensPrediction(TestCase):
+class TensorRecBiasedPrediction(TestCase):
+    # TODO: Collapse these into TensorRecTestCase once the fit bug is fixed
 
     @classmethod
     def setUpClass(cls):

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 from tensorrec import TensorRec
 from tensorrec.util import generate_dummy_data_with_indicator, generate_dummy_data
 from tensorrec.session_management import set_session
-from test.datasets import get_movielens_100k
 
 
 class TensorRecTestCase(TestCase):
@@ -133,21 +132,20 @@ class TensorRecMovielensPrediction(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.movielens_100k = get_movielens_100k()
-        train_interactions, test_interactions, cls.user_features, cls.item_features, _ = cls.movielens_100k
-        cls.model = TensorRec()
-        cls.model.fit(
-            interactions=train_interactions,
-            user_features=cls.user_features,
-            item_features=cls.item_features,
-            epochs=5)
+        cls.interactions, cls.user_features, cls.item_features = generate_dummy_data(
+            num_users=15, num_items=30, interaction_density=.5, num_user_features=200, num_item_features=200,
+            n_features_per_user=20, n_features_per_item=20, pos_int_ratio=.5
+        )
+
+        cls.standard_model = TensorRec(n_components=10)
+        cls.standard_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
 
     def test_predict_user_bias(self):
-        user_bias = self.model.predict_user_bias(self.user_features)
+        user_bias = self.standard_model.predict_user_bias(self.user_features)
         self.assertTrue(any(user_bias))  # Make sure it isn't all 0s
 
     def test_predict_item_bias(self):
-        item_bias = self.model.predict_item_bias(self.item_features)
+        item_bias = self.standard_model.predict_item_bias(self.item_features)
         self.assertTrue(any(item_bias))  # Make sure it isn't all 0s
 
 

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -115,6 +115,14 @@ class TensorRecTestCase(TestCase):
         item_repr = self.unbiased_model.predict_item_representation(self.item_features)
         self.assertEqual(item_repr.shape, (self.item_features.shape[0], 10))
 
+    def test_predict_user_bias(self):
+        user_bias = self.standard_model.predict_user_bias(self.user_features)
+        print(user_bias)  # TODO what are expected values?
+
+    def test_predict_item_bias(self):
+        item_bias = self.standard_model.predict_item_bias(self.item_features)
+        print(item_bias)  # TODO what are expected values?
+
 
 class TensorRecNormalizedTestCase(TensorRecTestCase):
 

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -8,6 +8,7 @@ import tensorflow as tf
 from tensorrec import TensorRec
 from tensorrec.util import generate_dummy_data_with_indicator, generate_dummy_data
 from tensorrec.session_management import set_session
+from test.datasets import get_movielens_100k
 
 
 class TensorRecTestCase(TestCase):
@@ -127,13 +128,27 @@ class TensorRecTestCase(TestCase):
             self.unbiased_model.predict_item_bias,
             self.item_features)
 
+
+class TensorRecMovielensPrediction(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.movielens_100k = get_movielens_100k()
+        train_interactions, test_interactions, cls.user_features, cls.item_features, _ = cls.movielens_100k
+        cls.model = TensorRec()
+        cls.model.fit(
+            interactions=train_interactions,
+            user_features=cls.user_features,
+            item_features=cls.item_features,
+            epochs=5)
+
     def test_predict_user_bias(self):
-        user_bias = self.standard_model.predict_user_bias(self.user_features)
-        print(user_bias)  # TODO what are expected values?
+        user_bias = self.model.predict_user_bias(self.user_features)
+        self.assertTrue(any(user_bias))  # Make sure it isn't all 0s
 
     def test_predict_item_bias(self):
-        item_bias = self.standard_model.predict_item_bias(self.item_features)
-        print(item_bias)  # TODO what are expected values?
+        item_bias = self.model.predict_item_bias(self.item_features)
+        self.assertTrue(any(item_bias))  # Make sure it isn't all 0s
 
 
 class TensorRecNormalizedTestCase(TensorRecTestCase):


### PR DESCRIPTION
Closes #38.

Adds `TensorRec#predict_user_biases` and `TensorRec#predict_item_biases`, for use on biased models.