### PR TITLE
ENH: Adds mixture-of-tastes functionality and tests

### DIFF
--- a/examples/check_movielens_losses.py
+++ b/examples/check_movielens_losses.py
@@ -35,9 +35,10 @@ header = "Loss Graph"
 header = append_to_string_at_point(header, 'Prediction Graph', 30)
 header = append_to_string_at_point(header, 'ItemRepr Graph', 66)
 header = append_to_string_at_point(header, 'Biased', 98)
-header = append_to_string_at_point(header, 'Recall at 30', 110)
-header = append_to_string_at_point(header, 'Precision at 5', 131)
-header = append_to_string_at_point(header, 'NDCG at 30', 154)
+header = append_to_string_at_point(header, 'N Tastes', 108)
+header = append_to_string_at_point(header, 'Recall at 30', 120)
+header = append_to_string_at_point(header, 'Precision at 5', 141)
+header = append_to_string_at_point(header, 'NDCG at 30', 164)
 res_strings.append(header)
 
 for biased in (True, False):
@@ -45,26 +46,29 @@ for biased in (True, False):
         for pred_graph in (DotProductPredictionGraph, CosineSimilarityPredictionGraph,
                            EuclidianSimilarityPredictionGraph):
             for repr_graph in (LinearRepresentationGraph, ReLURepresentationGraph):
+                for n_tastes in (1, 3):
 
-                model = TensorRec(n_components=n_components,
-                                  biased=biased,
-                                  loss_graph=loss_graph(),
-                                  prediction_graph=pred_graph(),
-                                  user_repr_graph=LinearRepresentationGraph(),
-                                  item_repr_graph=repr_graph())
-                result = fit_and_eval(model, user_features, item_features, train_interactions, test_interactions,
-                                      fit_kwargs)
+                    model = TensorRec(n_components=n_components,
+                                      n_tastes=n_tastes,
+                                      biased=biased,
+                                      loss_graph=loss_graph(),
+                                      prediction_graph=pred_graph(),
+                                      user_repr_graph=LinearRepresentationGraph(),
+                                      item_repr_graph=repr_graph())
+                    result = fit_and_eval(model, user_features, item_features, train_interactions, test_interactions,
+                                          fit_kwargs)
 
-                res_string = "{}".format(loss_graph.__name__)
-                res_string = append_to_string_at_point(res_string, pred_graph.__name__, 30)
-                res_string = append_to_string_at_point(res_string, repr_graph.__name__, 66)
-                res_string = append_to_string_at_point(res_string, biased, 98)
-                res_string = append_to_string_at_point(res_string, ": {}".format(result[0]), 108)
-                res_string = append_to_string_at_point(res_string, result[1], 131)
-                res_string = append_to_string_at_point(res_string, result[2], 154)
+                    res_string = "{}".format(loss_graph.__name__)
+                    res_string = append_to_string_at_point(res_string, pred_graph.__name__, 30)
+                    res_string = append_to_string_at_point(res_string, repr_graph.__name__, 66)
+                    res_string = append_to_string_at_point(res_string, biased, 98)
+                    res_string = append_to_string_at_point(res_string, n_tastes, 108)
+                    res_string = append_to_string_at_point(res_string, ": {}".format(result[0]), 118)
+                    res_string = append_to_string_at_point(res_string, result[1], 141)
+                    res_string = append_to_string_at_point(res_string, result[2], 164)
 
-                print(res_string)
-                res_strings.append(res_string)
+                    print(res_string)
+                    res_strings.append(res_string)
 
 print('--------------------------------------------------')
 for res_string in res_strings:

--- a/tensorrec/recommendation_graphs.py
+++ b/tensorrec/recommendation_graphs.py
@@ -80,3 +80,14 @@ def rank_predictions(tf_prediction):
     tf_prediction_item_size = tf.shape(tf_prediction)[1]
     tf_indices_of_ranks = tf.nn.top_k(tf_prediction, k=tf_prediction_item_size)[1]
     return tf.nn.top_k(-tf_indices_of_ranks, k=tf_prediction_item_size)[1] + 1
+
+
+def collapse_mixture_of_tastes(tastes_predictions):
+    """
+    Collapses a list of prediction nodes in to a single prediction node.
+    :param tastes_predictions:
+    :return:
+    """
+    stacked_tastes = tf.stack(tastes_predictions)
+    max_prediction = tf.reduce_max(stacked_tastes, axis=0)
+    return max_prediction

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from tensorrec.recommendation_graphs import (
     project_biases, split_sparse_tensor_indices, bias_prediction_dense, bias_prediction_serial,
-    densify_sampled_item_predictions, rank_predictions
+    densify_sampled_item_predictions, rank_predictions, collapse_mixture_of_tastes
 )
 from tensorrec.session_management import get_session
 
@@ -135,3 +135,17 @@ class RecommendationGraphsTestCase(TestCase):
             [2, 1, 4, 3],
         ], dtype=np.int)
         self.assertTrue((ranked == expected_ranks).all())
+
+    def test_collapse_mixture_of_tastes(self):
+        predictions = [
+            np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32),
+            np.array([4.0, 3.0, 2.0, 1.0], dtype=np.float32),
+            np.array([3.0, 4.0, 1.0, 2.0], dtype=np.float32),
+        ]
+
+        collapsed_predictions = collapse_mixture_of_tastes(predictions).eval(session=self.session)
+
+        expected_predictions = np.array([
+            [4.0, 4.0, 3.0, 4.0],
+        ], dtype=np.float32)
+        self.assertTrue((collapsed_predictions == expected_predictions).all())

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -165,6 +165,28 @@ class TensorRecNormalizedTestCase(TensorRecTestCase):
         cls.unbiased_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
 
 
+class TensorRecNTastesTestCase(TensorRecTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.interactions, cls.user_features, cls.item_features = generate_dummy_data(
+            num_users=15, num_items=30, interaction_density=.5, num_user_features=200, num_item_features=200,
+            n_features_per_user=20, n_features_per_item=20, pos_int_ratio=.5
+        )
+
+        cls.standard_model = TensorRec(n_components=10, n_tastes=3)
+        cls.standard_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
+
+        cls.unbiased_model = TensorRec(n_components=10, n_tastes=3, biased=False)
+        cls.unbiased_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
+
+    def test_predict_user_repr(self):
+        user_repr = self.unbiased_model.predict_user_representation(self.user_features)
+
+        # 3 tastes, shape[0] users, 10 components
+        self.assertEqual(user_repr.shape, (3, self.user_features.shape[0], 10))
+
+
 class TensorRecSavingTestCase(TestCase):
 
     @classmethod


### PR DESCRIPTION
Closes #47 

1. Adds the ability to specify the number of tastes per user. Tastes are expressed as parallel representation and prediction graphs. A prediction is made by taking the maximum prediction from all of a user's tastes.
2. Adds tests for mixture of tastes.
3. Preserves user_repr API to return a rank 2 user repr when `n_tastes == 1`, otherwise returns rank 3 user representations.