### PR TITLE
ENH: Adds attention

### DIFF
--- a/examples/attention_example.py
+++ b/examples/attention_example.py
@@ -1,0 +1,57 @@
+from tensorrec import TensorRec
+from tensorrec.eval import fit_and_eval
+from tensorrec.representation_graphs import (
+    LinearRepresentationGraph, NormalizedLinearRepresentationGraph
+)
+from tensorrec.loss_graphs import BalancedWMRBLossGraph
+
+from test.datasets import get_movielens_100k
+
+import logging
+logging.getLogger().setLevel(logging.INFO)
+
+# Load the movielens dataset
+train_interactions, test_interactions, user_features, item_features, _ = get_movielens_100k(negative_value=0)
+
+# Construct parameters for fitting
+epochs = 500
+alpha = 0.00001
+n_components = 10
+verbose = True
+learning_rate = .01
+n_sampled_items = int(item_features.shape[0] * .1)
+fit_kwargs = {'epochs': epochs, 'alpha': alpha, 'verbose': verbose, 'learning_rate': learning_rate,
+              'n_sampled_items': n_sampled_items}
+
+# Build two models -- one without an attention graph, one with a linear attention graph
+model_without_attention = TensorRec(
+    n_components=10,
+    n_tastes=3,
+    user_repr_graph=NormalizedLinearRepresentationGraph(),
+    attention_graph=None,
+    loss_graph=BalancedWMRBLossGraph(),
+)
+
+model_with_attention = TensorRec(
+    n_components=10,
+    n_tastes=3,
+    user_repr_graph=NormalizedLinearRepresentationGraph(),
+    attention_graph=LinearRepresentationGraph(),
+    loss_graph=BalancedWMRBLossGraph(),
+)
+
+results_without_attention = fit_and_eval(model=model_without_attention,
+                                         user_features=user_features,
+                                         item_features=item_features,
+                                         train_interactions=train_interactions,
+                                         test_interactions=test_interactions,
+                                         fit_kwargs=fit_kwargs)
+results_with_attention = fit_and_eval(model=model_with_attention,
+                                      user_features=user_features,
+                                      item_features=item_features,
+                                      train_interactions=train_interactions,
+                                      test_interactions=test_interactions,
+                                      fit_kwargs=fit_kwargs)
+
+logging.info("Results without attention: {}".format(results_without_attention))
+logging.info("Results with attention:    {}".format(results_with_attention))

--- a/examples/plot_movielens.py
+++ b/examples/plot_movielens.py
@@ -11,8 +11,7 @@ import numpy as np
 from tensorrec import TensorRec
 from tensorrec.eval import precision_at_k, recall_at_k
 from tensorrec.loss_graphs import BalancedWMRBLossGraph
-from tensorrec.prediction_graphs import DotProductPredictionGraph
-from tensorrec.representation_graphs import NormalizedLinearRepresentationGraph
+from tensorrec.representation_graphs import ReLURepresentationGraph
 
 from test.datasets import get_movielens_100k
 
@@ -31,10 +30,9 @@ fit_kwargs = {'epochs': 1, 'alpha': 0.0001, 'verbose': True, 'learning_rate': .0
 
 # Build the TensorRec model
 model = TensorRec(n_components=2,
-                  biased=True,
+                  biased=False,
                   loss_graph=BalancedWMRBLossGraph(),
-                  prediction_graph=DotProductPredictionGraph(),
-                  user_repr_graph=NormalizedLinearRepresentationGraph(),
+                  item_repr_graph=ReLURepresentationGraph(),
                   normalize_users=True,
                   normalize_items=True,
                   n_tastes=3)
@@ -48,11 +46,9 @@ for epoch in range(epochs):
     model.fit_partial(interactions=train_interactions, user_features=user_features, item_features=item_features,
                       **fit_kwargs)
 
-    # The position of a movie or user is that movie's/user's 2-dimensional representation. The size of the movie dot is
-    # related to its item bias.
+    # The position of a movie or user is that movie's/user's 2-dimensional representation.
     movie_positions = model.predict_item_representation(item_features)
     user_positions = model.predict_user_representation(user_features)
-    movie_sizes = model.predict_item_bias(item_features) * 10 + 1.0
 
     # Handle multiple tastes, if applicable. If there are more than 1 taste per user, only the first of each user's
     # tastes will be plotted.
@@ -64,7 +60,7 @@ for epoch in range(epochs):
     ax.axhline(y=0, color='k')
     ax.axvline(x=0, color='k')
     ax.scatter(*zip(*user_positions[user_to_plot]), color='r', s=1)
-    ax.scatter(*zip(*movie_positions[movies_to_plot]), s=movie_sizes)
+    ax.scatter(*zip(*movie_positions[movies_to_plot]), s=2)
     ax.set_aspect('equal')
 
     for i, movie in enumerate(movies_to_plot):

--- a/tensorrec/recommendation_graphs.py
+++ b/tensorrec/recommendation_graphs.py
@@ -121,16 +121,17 @@ def relative_cosine(tf_tensor_1, tf_tensor_2):
     return tf.matmul(normalized_t1, normalized_t2, transpose_b=True)
 
 
-def predict_similar_items(tf_item_representation, tf_similar_items_ids):
+def predict_similar_items(prediction_graph_factory, tf_item_representation, tf_similar_items_ids):
     """
-    Calculates the cosine between the given item ids and all other items.
+    Calculates the similarity between the given item ids and all other items using the prediction graph.
+    :param prediction_graph_factory:
     :param tf_item_representation:
     :param tf_similar_items_ids:
     :return:
     """
     gathered_items = tf.gather(tf_item_representation, tf_similar_items_ids)
-    sims = relative_cosine(
-        tf_tensor_1=gathered_items,
-        tf_tensor_2=tf_item_representation
+    sims = prediction_graph_factory.connect_dense_prediction_graph(
+        tf_user_representation=gathered_items,
+        tf_item_representation=tf_item_representation
     )
     return sims

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -437,7 +437,8 @@ class TensorRec(object):
 
         # Construct API nodes
         self.tf_rankings = rank_predictions(tf_prediction=self.tf_prediction)
-        self.tf_predict_similar_items = predict_similar_items(tf_item_representation=self.tf_item_representation,
+        self.tf_predict_similar_items = predict_similar_items(prediction_graph_factory=self.prediction_graph_factory,
+                                                              tf_item_representation=self.tf_item_representation,
                                                               tf_similar_items_ids=self.tf_similar_items_ids)
         self.tf_rank_similar_items = rank_predictions(tf_prediction=self.tf_predict_similar_items)
 

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -24,6 +24,7 @@ class TensorRec(object):
                  n_tastes=1,
                  user_repr_graph=LinearRepresentationGraph(),
                  item_repr_graph=LinearRepresentationGraph(),
+                 attention_graph=None,
                  prediction_graph=DotProductPredictionGraph(),
                  loss_graph=RMSELossGraph(),
                  biased=True,
@@ -41,6 +42,9 @@ class TensorRec(object):
         :param item_repr_graph: AbstractRepresentationGraph
         An object which inherits AbstractRepresentationGraph that contains a method to calculate item representations.
         See tensorrec.representation_graphs for examples.
+        :param attention_graph: AbstractRepresentationGraph or None
+        An object which inherits AbstractRepresentationGraph that contains a method to calculate user attention. Any
+        valid repr_graph is also a valid attention graph. If None, no attention process will be applied.
         :param prediction_graph: AbstractPredictionGraph
         An object which inherits AbstractPredictionGraph that contains a method to calculate predictions from a pair of
         user/item reprs.
@@ -72,11 +76,17 @@ class TensorRec(object):
             raise ValueError("prediction_graph must inherit AbstractPredictionGraph")
         if not isinstance(loss_graph, AbstractLossGraph):
             raise ValueError("loss_graph must inherit AbstractLossGraph")
+        if attention_graph is not None:
+            if not isinstance(attention_graph, AbstractRepresentationGraph):
+                raise ValueError("attention_graph must be None or inherit AbstractRepresentationGraph")
+            if n_tastes == 1:
+                raise ValueError("attention_graph must be None if n_tastes == 1")
 
         self.n_components = n_components
         self.n_tastes = n_tastes
         self.user_repr_graph_factory = user_repr_graph
         self.item_repr_graph_factory = item_repr_graph
+        self.attention_graph_factory = attention_graph
         self.prediction_graph_factory = prediction_graph
         self.loss_graph_factory = loss_graph
         self.biased = biased
@@ -299,12 +309,23 @@ class TensorRec(object):
         tf_x_user_sample = tf_transposed_sample_indices[0]
         tf_x_item_sample = tf_transposed_sample_indices[1]
 
-        # Build n_tastes user representations and predictions
+        # These lists will hold the reprs and predictions for each taste
         tastes_tf_user_representations = []
         tastes_tf_predictions = []
         tastes_tf_prediction_serials = []
         tastes_tf_sample_prediction_serials = []
 
+        # If this model does not use attention, Nones are used as sentinels in place of the attentions
+        if self.attention_graph_factory is not None:
+            tastes_tf_attentions = []
+            tastes_tf_attention_serials = []
+            tastes_tf_sample_attention_serials = []
+        else:
+            tastes_tf_attentions = None
+            tastes_tf_attention_serials = None
+            tastes_tf_sample_attention_serials = None
+
+        # Build n_tastes user representations and predictions
         for taste in range(self.n_tastes):
             tf_user_representation, user_weights = \
                 self.user_repr_graph_factory.connect_representation_graph(tf_features=tf_user_features,
@@ -313,6 +334,36 @@ class TensorRec(object):
                                                                           node_name_ending='user_{}'.format(taste))
             tastes_tf_user_representations.append(tf_user_representation)
             tf_weights.extend(user_weights)
+
+            # Connect attention, if applicable
+            if self.attention_graph_factory is not None:
+                tf_attention_representation, attention_weights = \
+                    self.attention_graph_factory.connect_representation_graph(tf_features=tf_user_features,
+                                                                              n_components=self.n_components,
+                                                                              n_features=n_user_features,
+                                                                              node_name_ending='attn_{}'.format(taste))
+                tf_weights.extend(attention_weights)
+
+                tf_attention = self.prediction_graph_factory.connect_dense_prediction_graph(
+                    tf_user_representation=tf_attention_representation,
+                    tf_item_representation=self.tf_item_representation
+                )
+                tf_attention_serial = self.prediction_graph_factory.connect_serial_prediction_graph(
+                    tf_user_representation=tf_attention_representation,
+                    tf_item_representation=self.tf_item_representation,
+                    tf_x_user=tf_x_user,
+                    tf_x_item=tf_x_item,
+                )
+                tf_sample_attention_serial = self.prediction_graph_factory.connect_serial_prediction_graph(
+                    tf_user_representation=tf_user_representation,
+                    tf_item_representation=self.tf_item_representation,
+                    tf_x_user=tf_x_user_sample,
+                    tf_x_item=tf_x_item_sample,
+                )
+
+                tastes_tf_attentions.append(tf_attention)
+                tastes_tf_attention_serials.append(tf_attention_serial)
+                tastes_tf_sample_attention_serials.append(tf_sample_attention_serial)
 
             # Connect the configurable prediction graphs for each taste
             tf_prediction = self.prediction_graph_factory.connect_dense_prediction_graph(
@@ -338,9 +389,18 @@ class TensorRec(object):
             tastes_tf_sample_prediction_serials.append(tf_sample_predictions_serial)
 
         self.tf_user_representation = tf.stack(tastes_tf_user_representations)
-        self.tf_prediction = collapse_mixture_of_tastes(tastes_tf_predictions)
-        self.tf_prediction_serial = collapse_mixture_of_tastes(tastes_tf_prediction_serials)
-        tf_sample_predictions_serial = collapse_mixture_of_tastes(tastes_tf_sample_prediction_serials)
+        self.tf_prediction = collapse_mixture_of_tastes(
+            tastes_predictions=tastes_tf_predictions,
+            tastes_attentions=tastes_tf_attentions
+        )
+        self.tf_prediction_serial = collapse_mixture_of_tastes(
+            tastes_predictions=tastes_tf_prediction_serials,
+            tastes_attentions=tastes_tf_attention_serials
+        )
+        tf_sample_predictions_serial = collapse_mixture_of_tastes(
+            tastes_predictions=tastes_tf_sample_prediction_serials,
+            tastes_attentions=tastes_tf_sample_attention_serials
+        )
 
         # Add biases, if this is a biased estimator
         if self.biased:

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -143,9 +143,26 @@ class RecommendationGraphsTestCase(TestCase):
             np.array([3.0, 4.0, 1.0, 2.0], dtype=np.float32),
         ]
 
-        collapsed_predictions = collapse_mixture_of_tastes(predictions).eval(session=self.session)
+        collapsed_predictions = collapse_mixture_of_tastes(tastes_predictions=predictions,
+                                                           tastes_attentions=None).eval(session=self.session)
 
-        expected_predictions = np.array([
-            [4.0, 4.0, 3.0, 4.0],
-        ], dtype=np.float32)
+        expected_predictions = np.array([[4.0, 4.0, 3.0, 4.0]], dtype=np.float32)
+        self.assertTrue((collapsed_predictions == expected_predictions).all())
+
+    def test_collapse_mixture_of_tastes_with_attention(self):
+        predictions = [
+            np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32),
+            np.array([4.0, 3.0, 2.0, 1.0], dtype=np.float32),
+            np.array([3.0, 4.0, 1.0, 2.0], dtype=np.float32),
+        ]
+        attentions = [
+            np.array([1.0, 2.0, -3.0, 4.0], dtype=np.float32),
+            np.array([0.0, 3.0, 2.0, 1.0], dtype=np.float32),
+            np.array([3.0, 0.0, 1.0, 2.0], dtype=np.float32),
+        ]
+
+        collapsed_predictions = collapse_mixture_of_tastes(tastes_predictions=predictions,
+                                                           tastes_attentions=attentions).eval(session=self.session)
+
+        expected_predictions = np.array([[2.8136194, 2.7756228, 1.7372786, 3.6455793]], dtype=np.float32)
         self.assertTrue((collapsed_predictions == expected_predictions).all())

--- a/test/test_recommendation_graphs.py
+++ b/test/test_recommendation_graphs.py
@@ -3,9 +3,10 @@ import tensorflow as tf
 import scipy.sparse as sp
 from unittest import TestCase
 
+from tensorrec.prediction_graphs import CosineSimilarityPredictionGraph
 from tensorrec.recommendation_graphs import (
     project_biases, split_sparse_tensor_indices, bias_prediction_dense, bias_prediction_serial,
-    densify_sampled_item_predictions, rank_predictions, collapse_mixture_of_tastes
+    densify_sampled_item_predictions, rank_predictions, collapse_mixture_of_tastes, predict_similar_items
 )
 from tensorrec.session_management import get_session
 
@@ -166,3 +167,16 @@ class RecommendationGraphsTestCase(TestCase):
 
         expected_predictions = np.array([[2.8136194, 2.7756228, 1.7372786, 3.6455793]], dtype=np.float32)
         self.assertTrue((collapsed_predictions == expected_predictions).all())
+
+    def test_predict_similar_items(self):
+        reprs = np.array([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0, 0.0],
+        ], dtype=np.float32)
+        sims = predict_similar_items(prediction_graph_factory=CosineSimilarityPredictionGraph(),
+                                     tf_similar_items_ids=[1],
+                                     tf_item_representation=reprs).eval(session=self.session)
+
+        expected_sims = np.array([[0.0,  1.0, -1.0]], dtype=np.float32)
+        self.assertTrue((sims == expected_sims).all())

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -67,33 +67,6 @@ class TensorRecTestCase(TestCase):
 
         self.assertEqual(predictions.shape, (self.user_features.shape[0], self.item_features.shape[0]))
 
-    def test_predict_dot_product(self):
-        predictions = self.standard_model.predict_dot_product(user_features=self.user_features,
-                                                              item_features=self.item_features)
-
-        self.assertEqual(predictions.shape, (self.user_features.shape[0], self.item_features.shape[0]))
-
-    def test_predict_cosine_similarity(self):
-        cosines = self.standard_model.predict_cosine_similarity(user_features=self.user_features,
-                                                                item_features=self.item_features)
-
-        self.assertEqual(cosines.shape, (self.user_features.shape[0], self.item_features.shape[0]))
-        for x in range(cosines.shape[0]):
-            for y in range(cosines.shape[1]):
-                val = cosines[x][y]
-                self.assertGreaterEqual(val, -1.0)
-                self.assertLessEqual(val, 1.0)
-
-    def test_predict_euclidian_similarity(self):
-        cosines = self.standard_model.predict_euclidian_similarity(user_features=self.user_features,
-                                                                   item_features=self.item_features)
-
-        self.assertEqual(cosines.shape, (self.user_features.shape[0], self.item_features.shape[0]))
-        for x in range(cosines.shape[0]):
-            for y in range(cosines.shape[1]):
-                val = cosines[x][y]
-                self.assertLessEqual(val, 0.0)
-
     def test_predict_rank(self):
         ranks = self.standard_model.predict_rank(user_features=self.user_features,
                                                  item_features=self.item_features)

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import tensorflow as tf
 
 from tensorrec import TensorRec
-from tensorrec.representation_graphs import NormalizedLinearRepresentationGraph
+from tensorrec.representation_graphs import NormalizedLinearRepresentationGraph, LinearRepresentationGraph
 from tensorrec.session_management import set_session
 from tensorrec.util import generate_dummy_data_with_indicator, generate_dummy_data
 
@@ -44,6 +44,14 @@ class TensorRecTestCase(TestCase):
     def test_init_fail_bad_loss_graph(self):
         with self.assertRaises(ValueError):
             TensorRec(loss_graph=np.mean)
+
+    def test_init_fail_attention_with_1_taste(self):
+        with self.assertRaises(ValueError):
+            TensorRec(n_tastes=1, attention_graph=LinearRepresentationGraph())
+
+    def test_init_fail_bad_attention_graph(self):
+        with self.assertRaises(ValueError):
+            TensorRec(attention_graph=np.mean)
 
     def test_fit(self):
         # Ensure that the nodes have been built
@@ -176,6 +184,29 @@ class TensorRecNTastesTestCase(TensorRecTestCase):
 
         # 3 tastes, shape[0] users, 10 components
         self.assertEqual(user_repr.shape, (3, self.user_features.shape[0], 10))
+
+
+class TensorRecAttentionTestCase(TensorRecNTastesTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.interactions, cls.user_features, cls.item_features = generate_dummy_data(
+            num_users=15, num_items=30, interaction_density=.5, num_user_features=200, num_item_features=200,
+            n_features_per_user=20, n_features_per_item=20, pos_int_ratio=.5
+        )
+
+        cls.standard_model = TensorRec(n_components=10,
+                                       n_tastes=3,
+                                       user_repr_graph=NormalizedLinearRepresentationGraph(),
+                                       attention_graph=LinearRepresentationGraph())
+        cls.standard_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
+
+        cls.unbiased_model = TensorRec(n_components=10,
+                                       n_tastes=3,
+                                       biased=False,
+                                       user_repr_graph=NormalizedLinearRepresentationGraph(),
+                                       attention_graph=LinearRepresentationGraph())
+        cls.unbiased_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
 
 
 class TensorRecSavingTestCase(TestCase):


### PR DESCRIPTION
Closes #54 
Closes #55 

1. Adds `attention_graph` as a TensorRec arg that will build the mixture-of-tastes system with attention.
2. Adds MovieLens example with attention.
3. Tweaks other example scripts.
4. Adds tests for attention.
5. Removes the function-specific sims API methods.
6. Refactors item similarity API method to use the prediction graph.
7. Adds test for item similarity.