### PR TITLE
ENH: TFRecords and Datasets as input

### DIFF
--- a/examples/plot_movielens.py
+++ b/examples/plot_movielens.py
@@ -33,8 +33,6 @@ model = TensorRec(n_components=2,
                   biased=False,
                   loss_graph=BalancedWMRBLossGraph(),
                   item_repr_graph=ReLURepresentationGraph(),
-                  normalize_users=True,
-                  normalize_items=True,
                   n_tastes=3)
 
 # Make some random selections of movies and users we want to plot

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ flake8==3.3.0
 numpy==1.14.1
 scipy==0.19.1
 six==1.11.0
-tensorflow==1.5.0
+tensorflow==1.7.0

--- a/tensorrec/__init__.py
+++ b/tensorrec/__init__.py
@@ -1,5 +1,6 @@
 from .tensorrec import TensorRec
 from . import eval
+from . import input_utils
 from . import loss_graphs
 from . import representation_graphs
 from . import prediction_graphs
@@ -8,7 +9,9 @@ from . import util
 
 __version__ = '0.1'
 
-__all__ = [TensorRec, eval, util, loss_graphs, representation_graphs, prediction_graphs, session_management]
+__all__ = [
+    TensorRec, eval, util, loss_graphs, representation_graphs, prediction_graphs, session_management, input_utils
+]
 
 # Suppress TensorFlow logs
 import logging

--- a/tensorrec/input_utils.py
+++ b/tensorrec/input_utils.py
@@ -38,6 +38,21 @@ def create_tensorrec_dataset_from_sparse_matrix(sparse_matrix):
     return tf.data.Dataset.from_tensor_slices(tensor_slices)
 
 
+def write_tfrecord_from_sparse_matrix(tfrecord_path, sparse_matrix, session):
+    """
+    Writes the contents of a sparse matrix to a TFRecord file.
+    :param tfrecord_path: str
+    :param sparse_matrix: scipy.sparse matrix
+    :param session: tf.Session
+    :return: str
+    The tfrecord path
+    """
+    dataset = create_tensorrec_dataset_from_sparse_matrix(sparse_matrix=sparse_matrix)
+    return write_tfrecord_from_tensorrec_dataset(tfrecord_path=tfrecord_path,
+                                                 dataset=dataset,
+                                                 session=session)
+
+
 def get_dimensions_from_tensorrec_dataset(dataset, session):
     """
     Given a TensorFlow Dataset in the standard TensorRec format, returns the dimensions of the SparseTensor to be
@@ -60,6 +75,8 @@ def write_tfrecord_from_tensorrec_dataset(tfrecord_path, dataset, session):
     :param tfrecord_path: str
     :param dataset: tf.data.Dataset
     :param session: tf.Session
+    :return: str
+    The tfrecord path
     """
     iterator = create_tensorrec_iterator('dataset_writing_iterator')
     initializer = iterator.make_initializer(dataset)
@@ -84,6 +101,7 @@ def write_tfrecord_from_tensorrec_dataset(tfrecord_path, dataset, session):
     example = tf.train.Example(features=tf.train.Features(feature=feature))
     writer.write(example.SerializeToString())
     writer.close()
+    return tfrecord_path
 
 
 def create_tensorrec_dataset_from_tfrecord(tfrecord_path):

--- a/tensorrec/input_utils.py
+++ b/tensorrec/input_utils.py
@@ -5,6 +5,12 @@ import tensorflow as tf
 
 
 def create_tensorrec_iterator(name):
+    """
+    Creates a TensorFlow Iterator that is ready for the standard TensorRec data format.
+    :param name: str
+    The name for this Iterator.
+    :return: tf.data.Iterator
+    """
     return tf.data.Iterator.from_structure(
             output_types=(tf.int64, tf.float32, tf.int64, tf.int64),
             output_shapes=([None, 2], [None], [], []),
@@ -13,6 +19,12 @@ def create_tensorrec_iterator(name):
 
 
 def create_tensorrec_dataset_from_sparse_matrix(sparse_matrix):
+    """
+    Creates a TensorFlow Dataset containing the data from the given sparse matrix.
+    :param sparse_matrix: scipy.sparse matrix
+    The data to be contained in this Dataset.
+    :return: tf.data.Dataset
+    """
     if not isinstance(sparse_matrix, sp.coo_matrix):
         sparse_matrix = sp.coo_matrix(sparse_matrix)
 
@@ -27,6 +39,13 @@ def create_tensorrec_dataset_from_sparse_matrix(sparse_matrix):
 
 
 def get_dimensions_from_tensorrec_dataset(dataset, session):
+    """
+    Given a TensorFlow Dataset in the standard TensorRec format, returns the dimensions of the SparseTensor to be
+    populated by the Dataset.
+    :param dataset: tf.data.Dataset
+    :param session: tf.Session
+    :return: (int, int)
+    """
     iterator = create_tensorrec_iterator('dims_iterator')
     initializer = iterator.make_initializer(dataset)
     _, _, tf_d0, tf_d1 = iterator.get_next()

--- a/tensorrec/input_utils.py
+++ b/tensorrec/input_utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 from scipy import sparse as sp
-import six
 import tensorflow as tf
 
 
@@ -12,8 +11,8 @@ def create_tensorrec_iterator(name):
     :return: tf.data.Iterator
     """
     return tf.data.Iterator.from_structure(
-            output_types=(tf.int64, tf.float32, tf.int64, tf.int64),
-            output_shapes=([None, 2], [None], [], []),
+            output_types=(tf.int64, tf.int64, tf.float32, tf.int64, tf.int64),
+            output_shapes=([None], [None], [None], [], []),
             shared_name=name
     )
 
@@ -28,12 +27,13 @@ def create_tensorrec_dataset_from_sparse_matrix(sparse_matrix):
     if not isinstance(sparse_matrix, sp.coo_matrix):
         sparse_matrix = sp.coo_matrix(sparse_matrix)
 
-    indices = np.array([[pair for pair in six.moves.zip(sparse_matrix.row, sparse_matrix.col)]], dtype=np.int64)
+    row_index = np.array([sparse_matrix.row], dtype=np.int64)
+    col_index = np.array([sparse_matrix.col], dtype=np.int64)
     values = np.array([sparse_matrix.data], dtype=np.float32)
     n_dim_0 = np.array([sparse_matrix.shape[0]], dtype=np.int64)
     n_dim_1 = np.array([sparse_matrix.shape[1]], dtype=np.int64)
 
-    tensor_slices = (indices, values, n_dim_0, n_dim_1)
+    tensor_slices = (row_index, col_index, values, n_dim_0, n_dim_1)
 
     return tf.data.Dataset.from_tensor_slices(tensor_slices)
 
@@ -48,9 +48,51 @@ def get_dimensions_from_tensorrec_dataset(dataset, session):
     """
     iterator = create_tensorrec_iterator('dims_iterator')
     initializer = iterator.make_initializer(dataset)
-    _, _, tf_d0, tf_d1 = iterator.get_next()
-
+    _, _, _, tf_d0, tf_d1 = iterator.get_next()
     session.run(initializer)
     d0, d1 = session.run([tf_d0, tf_d1])
-
     return d0, d1
+
+
+def write_tfrecord_from_tensorrec_dataset(tfrecord_path, dataset, session):
+    iterator = create_tensorrec_iterator('dataset_writing_iterator')
+    initializer = iterator.make_initializer(dataset)
+    tf_row_index, tf_col_index, tf_values, tf_d0, tf_d1 = iterator.get_next()
+    session.run(initializer)
+    row_index, col_index, values, d0, d1 = session.run([tf_row_index, tf_col_index, tf_values, tf_d0, tf_d1])
+
+    def _int64_feature(int_values):
+        return tf.train.Feature(int64_list=tf.train.Int64List(value=int_values))
+
+    def _float_feature(float_values):
+        return tf.train.Feature(float_list=tf.train.FloatList(value=float_values))
+
+    writer = tf.python_io.TFRecordWriter(tfrecord_path)
+    feature = {
+        'row_index': _int64_feature(row_index),
+        'col_index': _int64_feature(col_index),
+        'values': _float_feature(values),
+        'd0': _int64_feature([d0]),
+        'd1': _int64_feature([d1]),
+    }
+    example = tf.train.Example(features=tf.train.Features(feature=feature))
+    writer.write(example.SerializeToString())
+    writer.close()
+
+
+def create_tensorrec_dataset_from_tfrecord(tfrecord_path):
+
+    def parse_tensorrec_tfrecord(example_proto):
+        features = {
+            'row_index': tf.FixedLenSequenceFeature((), tf.int64, allow_missing=True),
+            'col_index': tf.FixedLenSequenceFeature((), tf.int64, allow_missing=True),
+            'values': tf.FixedLenSequenceFeature((), tf.float32, allow_missing=True),
+            'd0': tf.FixedLenFeature((), tf.int64),
+            'd1': tf.FixedLenFeature((), tf.int64),
+        }
+        parsed_features = tf.parse_single_example(example_proto, features)
+        return (parsed_features['row_index'], parsed_features['col_index'], parsed_features['values'],
+                parsed_features['d0'], parsed_features['d1'])
+
+    dataset = tf.data.TFRecordDataset(tfrecord_path).map(parse_tensorrec_tfrecord)
+    return dataset

--- a/tensorrec/input_utils.py
+++ b/tensorrec/input_utils.py
@@ -1,0 +1,37 @@
+import numpy as np
+from scipy import sparse as sp
+import six
+import tensorflow as tf
+
+
+def create_tensorrec_iterator(name):
+    return tf.data.Iterator.from_structure(
+            output_types=(tf.int64, tf.float32, tf.int64, tf.int64),
+            output_shapes=([None, 2], [None], [], []),
+            shared_name=name
+    )
+
+
+def create_tensorrec_dataset_from_sparse_matrix(sparse_matrix):
+    if not isinstance(sparse_matrix, sp.coo_matrix):
+        sparse_matrix = sp.coo_matrix(sparse_matrix)
+
+    indices = np.array([[pair for pair in six.moves.zip(sparse_matrix.row, sparse_matrix.col)]], dtype=np.int64)
+    values = np.array([sparse_matrix.data], dtype=np.float32)
+    n_dim_0 = np.array([sparse_matrix.shape[0]], dtype=np.int64)
+    n_dim_1 = np.array([sparse_matrix.shape[1]], dtype=np.int64)
+
+    tensor_slices = (indices, values, n_dim_0, n_dim_1)
+
+    return tf.data.Dataset.from_tensor_slices(tensor_slices)
+
+
+def get_dimensions_from_tensorrec_dataset(dataset, session):
+    iterator = create_tensorrec_iterator('dims_iterator')
+    initializer = iterator.make_initializer(dataset)
+    _, _, tf_d0, tf_d1 = iterator.get_next()
+
+    session.run(initializer)
+    d0, d1 = session.run([tf_d0, tf_d1])
+
+    return d0, d1

--- a/tensorrec/input_utils.py
+++ b/tensorrec/input_utils.py
@@ -55,6 +55,12 @@ def get_dimensions_from_tensorrec_dataset(dataset, session):
 
 
 def write_tfrecord_from_tensorrec_dataset(tfrecord_path, dataset, session):
+    """
+    Writes the contents of a TensorRec Dataset to a TFRecord file.
+    :param tfrecord_path: str
+    :param dataset: tf.data.Dataset
+    :param session: tf.Session
+    """
     iterator = create_tensorrec_iterator('dataset_writing_iterator')
     initializer = iterator.make_initializer(dataset)
     tf_row_index, tf_col_index, tf_values, tf_d0, tf_d1 = iterator.get_next()
@@ -81,6 +87,11 @@ def write_tfrecord_from_tensorrec_dataset(tfrecord_path, dataset, session):
 
 
 def create_tensorrec_dataset_from_tfrecord(tfrecord_path):
+    """
+    Loads a TFRecord file and creates a Dataset with the contents.
+    :param tfrecord_path: str
+    :return: tf.data.Dataset
+    """
 
     def parse_tensorrec_tfrecord(example_proto):
         features = {

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -212,6 +212,7 @@ class TensorRec(object):
             interactions = interactions_batched
             user_features = user_features_batched
 
+        # TODO this is hand-wavy and begging for a cleaner refactor
         (int_ds, uf_ds, if_ds), (int_init, uf_init, if_init) = self._create_datasets_and_initializers(
             interactions=interactions, user_features=user_features, item_features=item_features
         )
@@ -490,12 +491,21 @@ class TensorRec(object):
             verbose=False, user_batch_size=None, n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
-        :param interactions: scipy.sparse matrix
+        :param interactions: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of interactions of shape [n_users, n_items].
-        :param user_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
-        :param item_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :param epochs: Integer
         The number of epochs to fit the model.
         :param learning_rate: Float
@@ -526,12 +536,21 @@ class TensorRec(object):
                     alpha=0.00001, verbose=False, user_batch_size=None, n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
-        :param interactions: scipy.sparse matrix
+        :param interactions: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of interactions of shape [n_users, n_items].
-        :param user_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
-        :param item_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :param epochs: Integer
         The number of epochs to fit the model.
         :param learning_rate: Float
@@ -613,10 +632,16 @@ class TensorRec(object):
     def predict(self, user_features, item_features):
         """
         Predict recommendation scores for the given users and items.
-        :param user_features: scipy.sparse matrix
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
-        :param item_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The predictions in an ndarray of shape [n_users, n_items]
         """
@@ -632,8 +657,11 @@ class TensorRec(object):
     def predict_similar_items(self, item_features, item_ids, n_similar):
         """
         Predicts the most similar items to the given item_ids.
-        :param item_features: scipy.sparse matrix
-        A matrix of user features of shape [n_users, n_user_features].
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
+        A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :param item_ids: list or np.array
         The ids of the items of interest.
         E.g. [4, 8, 12] to get sims for items 4, 8, and 12.
@@ -663,10 +691,16 @@ class TensorRec(object):
     def predict_rank(self, user_features, item_features):
         """
         Predict recommendation ranks for the given users and items.
-        :param user_features: scipy.sparse matrix
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
-        :param item_features: scipy.sparse matrix
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The ranks in an ndarray of shape [n_users, n_items]
         """
@@ -682,8 +716,11 @@ class TensorRec(object):
     def predict_user_representation(self, user_features):
         """
         Predict latent representation vectors for the given users.
-        :param user_features: scipy.sparse matrix
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The latent user representations in an ndarray of shape [n_users, n_components]
         """
@@ -703,8 +740,11 @@ class TensorRec(object):
     def predict_user_attention_representation(self, user_features):
         """
         Predict latent attention representation vectors for the given users.
-        :param user_features: scipy.sparse matrix
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The latent user attention representations in an ndarray of shape [n_users, n_components]
         """
@@ -728,8 +768,11 @@ class TensorRec(object):
     def predict_item_representation(self, item_features):
         """
         Predict representation vectors for the given items.
-        :param item_features: scipy.sparse matrix
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The latent item representations in an ndarray of shape [n_items, n_components]
         """
@@ -743,8 +786,11 @@ class TensorRec(object):
     def predict_user_bias(self, user_features):
         """
         Predict bias values for the given users.
-        :param user_features: scipy.sparse matrix
+        :param user_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of user features of shape [n_users, n_user_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The user biases in an ndarray of shape [n_users]
         """
@@ -761,8 +807,11 @@ class TensorRec(object):
     def predict_item_bias(self, item_features):
         """
         Predict bias values for the given items.
-        :param item_features: scipy.sparse matrix
+        :param item_features: scipy.sparse matrix, tensorflow.data.Dataset, str, or list
         A matrix of item features of shape [n_items, n_item_features].
+        If a Dataset, the Dataset must follow the format used in tensorrec.input_utils.
+        If a str, the string must be the path to a TFRecord file.
+        If a list, the list must contain scipy.sparse matrices, tensorflow.data.Datasets, or strs.
         :return: np.ndarray
         The item biases in an ndarray of shape [n_items]
         """

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -270,9 +270,16 @@ class TensorRec(object):
         self.tf_learning_rate = tf.placeholder('float', None)
         self.tf_alpha = tf.placeholder('float', None)
 
-        tf_user_feature_indices, tf_user_feature_values, tf_n_users, _ = self.tf_user_feature_iterator.get_next()
-        tf_item_feature_indices, tf_item_feature_values, tf_n_items, _ = self.tf_item_feature_iterator.get_next()
-        tf_interaction_indices, tf_interaction_values, _, _ = self.tf_interaction_iterator.get_next()
+        tf_user_feature_rows, tf_user_feature_cols, tf_user_feature_values, tf_n_users, _ = \
+            self.tf_user_feature_iterator.get_next()
+        tf_item_feature_rows, tf_item_feature_cols, tf_item_feature_values, tf_n_items, _ = \
+            self.tf_item_feature_iterator.get_next()
+        tf_interaction_rows, tf_interaction_cols, tf_interaction_values, _, _ = \
+            self.tf_interaction_iterator.get_next()
+
+        tf_user_feature_indices = tf.stack([tf_user_feature_rows, tf_user_feature_cols], axis=1)
+        tf_item_feature_indices = tf.stack([tf_item_feature_rows, tf_item_feature_cols], axis=1)
+        tf_interaction_indices = tf.stack([tf_interaction_rows, tf_interaction_cols], axis=1)
 
         # Construct the features and interactions as sparse matrices
         tf_user_features = tf.SparseTensor(tf_user_feature_indices, tf_user_feature_values,

--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -1,3 +1,4 @@
+from functools import partial
 import logging
 import numpy as np
 import os
@@ -104,9 +105,7 @@ class TensorRec(object):
             'tf_basic_loss', 'tf_weight_reg_loss', 'tf_loss',
 
             # Feed placeholders
-            'tf_n_users', 'tf_n_items', 'tf_user_feature_indices', 'tf_user_feature_values', 'tf_item_feature_indices',
-            'tf_item_feature_values', 'tf_interaction_indices', 'tf_interaction_values', 'tf_learning_rate', 'tf_alpha',
-            'tf_sample_indices', 'tf_n_sampled_items', 'tf_similar_items_ids'
+            'tf_learning_rate', 'tf_alpha', 'tf_sample_indices', 'tf_n_sampled_items', 'tf_similar_items_ids',
         ]
         if self.biased:
             self.graph_tensor_hook_attr_names += ['tf_projected_user_biases', 'tf_projected_item_biases']
@@ -114,25 +113,30 @@ class TensorRec(object):
             self.graph_tensor_hook_attr_names += ['tf_user_attention_representation']
 
         self.graph_operation_hook_attr_names = [
-
             # AdamOptimizer
             'tf_optimizer',
-
         ]
-        self._clear_graph_hook_attrs()
+        self.graph_iterator_hook_attr_names = [
+            # Input data iterators
+            'tf_user_feature_iterator', 'tf_item_feature_iterator', 'tf_interaction_iterator',
+        ]
+        self._break_graph_hooks()
 
         # A map of every graph hook attr name to the node name after construction
         # Tensors and operations are stored separated because they are handled differently by TensorFlow
         self.graph_tensor_hook_node_names = {}
         self.graph_operation_hook_node_names = {}
+        self.graph_iterator_hook_node_names = {}
 
-    def _clear_graph_hook_attrs(self):
+    def _break_graph_hooks(self):
         for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
             self.__setattr__(graph_tensor_hook_attr_name, None)
         for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
             self.__setattr__(graph_operation_hook_attr_name, None)
+        for graph_iterator_hook_attr_name in self.graph_iterator_hook_attr_names:
+            self.__setattr__(graph_iterator_hook_attr_name, None)
 
-    def _attach_graph_hook_attrs(self):
+    def _attach_graph_hooks(self):
         session = get_session()
 
         for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
@@ -145,72 +149,107 @@ class TensorRec(object):
             node = session.graph.get_operation_by_name(name=graph_operation_hook_node_name)
             self.__setattr__(graph_operation_hook_attr_name, node)
 
-    def _create_feed_dict(self, interactions_matrix, user_features_matrix, item_features_matrix,
-                          extra_feed_kwargs=None):
+        for graph_iterator_hook_attr_name in self.graph_iterator_hook_attr_names:
+            iterator_resource_name, output_types, output_shapes, output_classes = \
+                self.graph_iterator_hook_node_names[graph_iterator_hook_attr_name]
+            iterator_resource = session.graph.get_tensor_by_name(name=iterator_resource_name)
+            iterator = tf.data.Iterator(iterator_resource, None, output_types, output_shapes, output_classes)
+            self.__setattr__(graph_iterator_hook_attr_name, iterator)
+
+    def _record_graph_hook_names(self):
+
+        # Record serializable node names/info for each graph hook
+        for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
+            hook = self.__getattribute__(graph_tensor_hook_attr_name)
+            self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
+
+        for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
+            hook = self.__getattribute__(graph_operation_hook_attr_name)
+            self.graph_operation_hook_node_names[graph_operation_hook_attr_name] = hook.name
+
+        for graph_iterator_hook_attr_name in self.graph_iterator_hook_attr_names:
+            hook = self.__getattribute__(graph_iterator_hook_attr_name)
+            iterator_resource_name = hook._iterator_resource.name
+            output_types = hook._output_types
+            output_shapes = hook._output_shapes
+            output_classes = hook._output_classes
+            self.graph_iterator_hook_node_names[graph_iterator_hook_attr_name] = (
+                iterator_resource_name, output_types, output_shapes, output_classes
+            )
+
+    def _create_batched_dataset_initializers(self, interactions=None, user_features=None, item_features=None,
+                                             user_batch_size=None):
+
+        if not isinstance(interactions, sp.csr_matrix):
+            interactions = sp.csr_matrix(interactions)
+        if not isinstance(user_features, sp.csr_matrix):
+            user_features = sp.csr_matrix(user_features)
+
+        n_users = user_features.shape[0]
+
+        # Infer the batch size, if necessary
+        if user_batch_size is None:
+            user_batch_size = n_users
+
+        initializer_sets = []
+
+        item_feature_initializer = self._create_dataset_initializers(item_features_matrix=item_features)[0]
+
+        start_batch = 0
+        while start_batch < n_users:
+
+            # min() ensures that the batch bounds doesn't go past the end of the index
+            end_batch = min(start_batch + user_batch_size, n_users)
+
+            batch_interactions = interactions[start_batch:end_batch]
+            batch_user_features = user_features[start_batch:end_batch]
+
+            # TODO its inefficient to make so many copies of the item features
+            initializers = self._create_dataset_initializers(interactions_matrix=batch_interactions,
+                                                             user_features_matrix=batch_user_features)
+            initializers.append(item_feature_initializer)
+            initializer_sets.append(initializers)
+
+            start_batch = end_batch
+
+        return initializer_sets
+
+    def _create_dataset_initializers(self, interactions_matrix=None, user_features_matrix=None,
+                                     item_features_matrix=None):
 
         # Check that input data is of a sparse type
         if (interactions_matrix is not None) and (not sp.issparse(interactions_matrix)):
             raise Exception('Interactions must be a scipy sparse matrix')
-        if not sp.issparse(user_features_matrix):
+        if (user_features_matrix is not None) and (not sp.issparse(user_features_matrix)):
             raise Exception('User features must be a scipy sparse matrix')
-        if not sp.issparse(item_features_matrix):
+        if (item_features_matrix is not None) and (not sp.issparse(item_features_matrix)):
             raise Exception('Item features must be a scipy sparse matrix')
 
-        n_users, user_feature_indices, user_feature_values = self._process_matrix(user_features_matrix,
-                                                                                  normalize_rows=self.normalize_users)
-        n_items, item_feature_indices, item_feature_values = self._process_matrix(item_features_matrix,
-                                                                                  normalize_rows=self.normalize_items)
-
-        feed_dict = {self.tf_n_users: n_users,
-                     self.tf_n_items: n_items,
-                     self.tf_user_feature_indices: user_feature_indices,
-                     self.tf_user_feature_values: user_feature_values,
-                     self.tf_item_feature_indices: item_feature_indices,
-                     self.tf_item_feature_values: item_feature_values, }
+        initializers = []
 
         if interactions_matrix is not None:
             _, interaction_indices, interaction_values = self._process_matrix(interactions_matrix)
-            feed_dict[self.tf_interaction_indices] = interaction_indices
-            feed_dict[self.tf_interaction_values] = interaction_values
+            interactions_dataset = tf.data.Dataset.from_tensor_slices((interaction_indices, interaction_values))
+            interactions_initializer = self.tf_interaction_iterator.make_initializer(interactions_dataset)
+            initializers.append(interactions_initializer)
 
-        if extra_feed_kwargs:
-            feed_dict.update(extra_feed_kwargs)
+        if user_features_matrix is not None:
+            n_users, user_features_indices, user_features_values = self._process_matrix(user_features_matrix)
+            user_feature_dataset = tf.data.Dataset.from_tensor_slices((user_features_indices,
+                                                                       user_features_values,
+                                                                       n_users))
+            user_features_initializer = self.tf_user_feature_iterator.make_initializer(user_feature_dataset)
+            initializers.append(user_features_initializer)
 
-        return feed_dict
+        if item_features_matrix is not None:
+            n_items, item_features_indices, item_features_values = self._process_matrix(item_features_matrix)
+            item_feature_dataset = tf.data.Dataset.from_tensor_slices((item_features_indices,
+                                                                       item_features_values,
+                                                                       n_items))
+            item_features_initializer = self.tf_item_feature_iterator.make_initializer(item_feature_dataset)
+            initializers.append(item_features_initializer)
 
-    def _create_user_feed_dict(self, user_features_matrix, extra_feed_kwargs=None):
-
-        if not sp.issparse(user_features_matrix):
-            raise Exception('User features must be a scipy sparse matrix')
-
-        n_users, user_feature_indices, user_feature_values = self._process_matrix(user_features_matrix,
-                                                                                  normalize_rows=self.normalize_users)
-
-        feed_dict = {self.tf_n_users: n_users,
-                     self.tf_user_feature_indices: user_feature_indices,
-                     self.tf_user_feature_values: user_feature_values}
-
-        if extra_feed_kwargs:
-            feed_dict.update(extra_feed_kwargs)
-
-        return feed_dict
-
-    def _create_item_feed_dict(self, item_features_matrix, extra_feed_kwargs=None):
-
-        if not sp.issparse(item_features_matrix):
-            raise Exception('Item features must be a scipy sparse matrix')
-
-        n_items, item_feature_indices, item_feature_values = self._process_matrix(item_features_matrix,
-                                                                                  normalize_rows=self.normalize_items)
-
-        feed_dict = {self.tf_n_items: n_items,
-                     self.tf_item_feature_indices: item_feature_indices,
-                     self.tf_item_feature_values: item_feature_values}
-
-        if extra_feed_kwargs:
-            feed_dict.update(extra_feed_kwargs)
-
-        return feed_dict
+        return initializers
 
     def _process_matrix(self, features_matrix, normalize_rows=False):
 
@@ -224,75 +263,50 @@ class TensorRec(object):
             features_matrix = sp.coo_matrix(features_matrix)
 
         # "Actors" is used to signify "users or items" -- unused for interactions
-        n_actors = features_matrix.shape[0]
-        feature_indices = [pair for pair in six.moves.zip(features_matrix.row, features_matrix.col)]
-        feature_values = features_matrix.data
+        n_actors = np.array([features_matrix.shape[0]], dtype=np.int64)
+        feature_indices = np.array([[pair for pair in six.moves.zip(features_matrix.row, features_matrix.col)]],
+                                   dtype=np.int64)
+        feature_values = np.array([features_matrix.data], dtype=np.float32)
 
         return n_actors, feature_indices, feature_values
 
-    def _create_batch_feed_dicts(self, interactions, user_features, item_features, extra_feed_kwargs,
-                                 user_batch_size=None):
-
-        if not isinstance(interactions, sp.csr_matrix):
-            interactions = sp.csr_matrix(interactions)
-        if not isinstance(user_features, sp.csr_matrix):
-            user_features = sp.csr_matrix(user_features)
-
-        n_users = user_features.shape[0]
-
-        # Infer the batch size, if necessary
-        if user_batch_size is None:
-            user_batch_size = n_users
-
-        feed_dicts = []
-
-        start_batch = 0
-        while start_batch < n_users:
-
-            # min() ensures that the batch bounds doesn't go past the end of the index
-            end_batch = min(start_batch + user_batch_size, n_users)
-
-            batch_interactions = interactions[start_batch:end_batch]
-            batch_user_features = user_features[start_batch:end_batch]
-
-            # TODO its inefficient to make so many copies of the item features
-            feed_dict = self._create_feed_dict(interactions_matrix=batch_interactions,
-                                               user_features_matrix=batch_user_features,
-                                               item_features_matrix=item_features,
-                                               extra_feed_kwargs=extra_feed_kwargs)
-            feed_dicts.append(feed_dict)
-
-            start_batch = end_batch
-
-        return feed_dicts
-
     def _build_tf_graph(self, n_user_features, n_item_features):
 
-        # Initialize placeholder values for inputs
-        self.tf_n_users = tf.placeholder('int64')
-        self.tf_n_items = tf.placeholder('int64')
+        # Build placeholders
         self.tf_n_sampled_items = tf.placeholder('int64')
-
-        # SparseTensor placeholders
-        self.tf_user_feature_indices = tf.placeholder('int64', [None, 2])
-        self.tf_user_feature_values = tf.placeholder('float', [None])
-        self.tf_item_feature_indices = tf.placeholder('int64', [None, 2])
-        self.tf_item_feature_values = tf.placeholder('float', [None])
-        self.tf_interaction_indices = tf.placeholder('int64', [None, 2])
-        self.tf_interaction_values = tf.placeholder('float', [None])
         self.tf_similar_items_ids = tf.placeholder('int64', [None])
-
-        self.tf_sample_indices = tf.placeholder('int64', [None, None])
         self.tf_learning_rate = tf.placeholder('float', None)
         self.tf_alpha = tf.placeholder('float', None)
 
+        self.tf_user_feature_iterator = tf.data.Iterator.from_structure(output_types=(tf.int64, tf.float32, tf.int64),
+                                                                        output_shapes=([None, 2], [None], []),
+                                                                        shared_name='tf_user_feature_iterator')
+        tf_user_feature_indices, tf_user_feature_values, tf_n_users = self.tf_user_feature_iterator.get_next()
+
+        self.tf_item_feature_iterator = tf.data.Iterator.from_structure(output_types=(tf.int64, tf.float32, tf.int64),
+                                                                        output_shapes=([None, 2], [None], []),
+                                                                        shared_name='tf_item_feature_iterator')
+        tf_item_feature_indices, tf_item_feature_values, tf_n_items = self.tf_item_feature_iterator.get_next()
+
+        self.tf_interaction_iterator = tf.data.Iterator.from_structure(output_types=(tf.int64, tf.float32),
+                                                                       output_shapes=([None, None], [None]),
+                                                                       shared_name='tf_interaction_iterator')
+        tf_interaction_indices, tf_interaction_values = self.tf_interaction_iterator.get_next()
+
         # Construct the features and interactions as sparse matrices
-        tf_user_features = tf.SparseTensor(self.tf_user_feature_indices, self.tf_user_feature_values,
-                                           [self.tf_n_users, n_user_features])
-        tf_item_features = tf.SparseTensor(self.tf_item_feature_indices, self.tf_item_feature_values,
-                                           [self.tf_n_items, n_item_features])
-        tf_interactions = tf.SparseTensor(self.tf_interaction_indices, self.tf_interaction_values,
-                                          [self.tf_n_users, self.tf_n_items])
+        tf_user_features = tf.SparseTensor(tf_user_feature_indices, tf_user_feature_values,
+                                           [tf_n_users, n_user_features])
+        tf_item_features = tf.SparseTensor(tf_item_feature_indices, tf_item_feature_values,
+                                           [tf_n_items, n_item_features])
+        tf_interactions = tf.SparseTensor(tf_interaction_indices, tf_interaction_values,
+                                          [tf_n_users, tf_n_items])
+
+        # Construct the sampling py_func
+        sample_items_partial = partial(sample_items, replace=self.loss_graph_factory.is_sampled_with_replacement)
+        self.tf_sample_indices = tf.py_func(func=sample_items_partial,
+                                            inp=[tf_n_items, tf_n_users, self.tf_n_sampled_items],
+                                            Tout=tf.int64)
+        self.tf_sample_indices.set_shape([None, None])
 
         # Collect the weights for normalization
         tf_weights = []
@@ -457,8 +471,8 @@ class TensorRec(object):
             'tf_prediction_serial': self.tf_prediction_serial,
             'tf_interactions_serial': tf_interactions_serial,
             'tf_interactions': tf_interactions,
-            'tf_n_users': self.tf_n_users,
-            'tf_n_items': self.tf_n_items,
+            'tf_n_users': tf_n_users,
+            'tf_n_items': tf_n_items,
         }
         if self.loss_graph_factory.is_dense:
             loss_graph_kwargs.update({
@@ -469,7 +483,7 @@ class TensorRec(object):
             tf_sample_predictions = densify_sampled_item_predictions(
                 tf_sample_predictions_serial=tf_sample_predictions_serial,
                 tf_n_sampled_items=self.tf_n_sampled_items,
-                tf_n_users=self.tf_n_users,
+                tf_n_users=tf_n_users,
             )
             loss_graph_kwargs.update({'tf_sample_predictions': tf_sample_predictions,
                                       'tf_n_sampled_items': self.tf_n_sampled_items})
@@ -481,16 +495,11 @@ class TensorRec(object):
         self.tf_loss = self.tf_basic_loss + (self.tf_alpha * self.tf_weight_reg_loss)
         self.tf_optimizer = tf.train.AdamOptimizer(learning_rate=self.tf_learning_rate).minimize(self.tf_loss)
 
-        # Get node names for each graph hook
-        for graph_tensor_hook_attr_name in self.graph_tensor_hook_attr_names:
-            hook = self.__getattribute__(graph_tensor_hook_attr_name)
-            self.graph_tensor_hook_node_names[graph_tensor_hook_attr_name] = hook.name
-        for graph_operation_hook_attr_name in self.graph_operation_hook_attr_names:
-            hook = self.__getattribute__(graph_operation_hook_attr_name)
-            self.graph_operation_hook_node_names[graph_operation_hook_attr_name] = hook.name
+        # Record the new node names
+        self._record_graph_hook_names()
 
     def fit(self, interactions, user_features, item_features, epochs=100, learning_rate=0.1, alpha=0.00001,
-            verbose=False, out_sample_interactions=None, user_batch_size=None, n_sampled_items=None):
+            verbose=False, user_batch_size=None, n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
         :param interactions: scipy.sparse matrix
@@ -507,9 +516,6 @@ class TensorRec(object):
         The weight regularization loss coefficient.
         :param verbose: boolean
         If true, the model will print a number of status statements during fitting.
-        :param out_sample_interactions: scipy.sparse matrix
-        A matrix of interactions of shape [n_users, n_items].
-        If not None, and verbose == True, the model will be evaluated on these interactions on every epoch.
         :param user_batch_size: int or None
         The maximum number of users per batch, or None for all users.
         :param n_sampled_items: int or None
@@ -525,13 +531,11 @@ class TensorRec(object):
                          learning_rate=learning_rate,
                          alpha=alpha,
                          verbose=verbose,
-                         out_sample_interactions=out_sample_interactions,
                          user_batch_size=user_batch_size,
                          n_sampled_items=n_sampled_items)
 
     def fit_partial(self, interactions, user_features, item_features, epochs=1, learning_rate=0.1,
-                    alpha=0.00001, verbose=False, out_sample_interactions=None, user_batch_size=None,
-                    n_sampled_items=None):
+                    alpha=0.00001, verbose=False, user_batch_size=None, n_sampled_items=None):
         """
         Constructs the TensorRec graph and fits the model.
         :param interactions: scipy.sparse matrix
@@ -548,9 +552,6 @@ class TensorRec(object):
         The weight regularization loss coefficient.
         :param verbose: boolean
         If true, the model will print a number of status statements during fitting.
-        :param out_sample_interactions: scipy.sparse matrix
-        A matrix of interactions of shape [n_users, n_items].
-        If not None, and verbose == True, the model will be evaluated on these interactions on every epoch.
         :param user_batch_size: int or None
         The maximum number of users per batch, or None for all users.
         :param n_sampled_items: int or None
@@ -578,33 +579,24 @@ class TensorRec(object):
         if verbose:
             logging.info('Processing interaction and feature data')
 
-        batched_feed_dicts = self._create_batch_feed_dicts(interactions=interactions,
-                                                           user_features=user_features,
-                                                           item_features=item_features,
-                                                           user_batch_size=user_batch_size,
-                                                           extra_feed_kwargs={self.tf_learning_rate: learning_rate})
+        initializer_sets = self._create_batched_dataset_initializers(interactions=interactions,
+                                                                     user_features=user_features,
+                                                                     item_features=item_features,
+                                                                     user_batch_size=user_batch_size)
 
-        # This scales down the alpha based on the number of batches and inserts the new alpha in all feed dicts
-        batched_alpha = calculate_batched_alpha(num_batches=len(batched_feed_dicts), alpha=alpha)
-        for feed_dict in batched_feed_dicts:
-            feed_dict[self.tf_alpha] = batched_alpha
+        # Build the shared feed dict
+        feed_dict = {self.tf_learning_rate: learning_rate,
+                     self.tf_alpha: calculate_batched_alpha(num_batches=len(initializer_sets), alpha=alpha)}
+        if self.loss_graph_factory.is_sample_based:
+            feed_dict[self.tf_n_sampled_items] = n_sampled_items
 
         if verbose:
             logging.info('Beginning fitting')
 
         for epoch in range(epochs):
-            for batch, feed_dict in enumerate(batched_feed_dicts):
+            for batch, initializers in enumerate(initializer_sets):
 
-                # Handle random item sampling, if applicable
-                if self.loss_graph_factory.is_sample_based:
-                    sample_indices = sample_items(n_users=feed_dict[self.tf_n_users],
-                                                  n_items=feed_dict[self.tf_n_items],
-                                                  n_sampled_items=n_sampled_items,
-                                                  replace=self.loss_graph_factory.is_sampled_with_replacement)
-                    feed_dict[self.tf_sample_indices] = sample_indices
-                    feed_dict[self.tf_n_sampled_items] = n_sampled_items
-
-                # TODO find something more elegant than these cascaded ifs
+                session.run(initializers)
                 if not verbose:
                     session.run(self.tf_optimizer, feed_dict=feed_dict)
 
@@ -619,10 +611,6 @@ class TensorRec(object):
                     logging.info('EPOCH {} BATCH {} loss = {}, weight_reg_l2_loss = {}, mean_pred = {}'.format(
                         epoch, batch, mean_loss, weight_reg_l2_loss, mean_pred
                     ))
-                    if out_sample_interactions:
-                        os_feed_dict = self._create_feed_dict(out_sample_interactions, user_features, item_features)
-                        os_loss = self.tf_basic_loss.eval(session=session, feed_dict=os_feed_dict)
-                        logging.info('Out-Sample loss = {}'.format(os_loss))
 
     def predict(self, user_features, item_features):
         """
@@ -634,11 +622,12 @@ class TensorRec(object):
         :return: np.ndarray
         The predictions in an ndarray of shape [n_users, n_items]
         """
-        feed_dict = self._create_feed_dict(interactions_matrix=None,
-                                           user_features_matrix=user_features,
-                                           item_features_matrix=item_features)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=user_features,
+                                                         item_features_matrix=item_features)
+        get_session().run(initializers)
 
-        predictions = self.tf_prediction.eval(session=get_session(), feed_dict=feed_dict)
+        predictions = self.tf_prediction.eval(session=get_session())
 
         return predictions
 
@@ -656,9 +645,12 @@ class TensorRec(object):
         The first level list corresponds to input arg item_ids.
         The second level list is of length n_similar and contains tuples of (item_id, score) for each similar item.
         """
-        feed_dict = self._create_item_feed_dict(item_features_matrix=item_features)
-        feed_dict[self.tf_similar_items_ids] = np.array(item_ids)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=None,
+                                                         item_features_matrix=item_features)
+        get_session().run(initializers)
 
+        feed_dict = {self.tf_similar_items_ids: np.array(item_ids)}
         sims = self.tf_predict_similar_items.eval(session=get_session(), feed_dict=feed_dict)
 
         results = []
@@ -680,11 +672,12 @@ class TensorRec(object):
         :return: np.ndarray
         The ranks in an ndarray of shape [n_users, n_items]
         """
-        feed_dict = self._create_feed_dict(interactions_matrix=None,
-                                           user_features_matrix=user_features,
-                                           item_features_matrix=item_features)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=user_features,
+                                                         item_features_matrix=item_features)
+        get_session().run(initializers)
 
-        rankings = self.tf_rankings.eval(session=get_session(), feed_dict=feed_dict)
+        rankings = self.tf_rankings.eval(session=get_session())
 
         return rankings
 
@@ -696,8 +689,12 @@ class TensorRec(object):
         :return: np.ndarray
         The latent user representations in an ndarray of shape [n_users, n_components]
         """
-        feed_dict = self._create_user_feed_dict(user_features_matrix=user_features)
-        user_repr = self.tf_user_representation.eval(session=get_session(), feed_dict=feed_dict)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=user_features,
+                                                         item_features_matrix=None)
+        get_session().run(initializers)
+
+        user_repr = self.tf_user_representation.eval(session=get_session())
 
         # If there is only one user repr per user, collapse from rank 3 to rank 2
         if self.n_tastes == 1:
@@ -718,8 +715,11 @@ class TensorRec(object):
             raise ValueError("This TensorRec model does not use attention. Try re-building TensorRec with a valid "
                              "'attention_graph' arg.")
 
-        feed_dict = self._create_user_feed_dict(user_features_matrix=user_features)
-        user_attn_repr = self.tf_user_attention_representation.eval(session=get_session(), feed_dict=feed_dict)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=user_features,
+                                                         item_features_matrix=None)
+        get_session().run(initializers)
+        user_attn_repr = self.tf_user_attention_representation.eval(session=get_session())
 
         # If there is only one user attn repr per user, collapse from rank 3 to rank 2
         if self.n_tastes == 1:
@@ -735,8 +735,11 @@ class TensorRec(object):
         :return: np.ndarray
         The latent item representations in an ndarray of shape [n_items, n_components]
         """
-        feed_dict = self._create_item_feed_dict(item_features_matrix=item_features)
-        item_repr = self.tf_item_representation.eval(session=get_session(), feed_dict=feed_dict)
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=None,
+                                                         item_features_matrix=item_features)
+        get_session().run(initializers)
+        item_repr = self.tf_item_representation.eval(session=get_session())
         return item_repr
 
     def predict_user_bias(self, user_features):
@@ -749,8 +752,12 @@ class TensorRec(object):
         """
         if not self.biased:
             raise NotImplementedError('Cannot predict user bias for unbiased model')
-        feed_dict = self._create_user_feed_dict(user_features_matrix=user_features)
-        predictions = self.tf_projected_user_biases.eval(session=get_session(), feed_dict=feed_dict)
+
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=user_features,
+                                                         item_features_matrix=None)
+        get_session().run(initializers)
+        predictions = self.tf_projected_user_biases.eval(session=get_session())
         return predictions
 
     def predict_item_bias(self, item_features):
@@ -763,8 +770,12 @@ class TensorRec(object):
         """
         if not self.biased:
             raise NotImplementedError('Cannot predict item bias for unbiased model')
-        feed_dict = self._create_item_feed_dict(item_features_matrix=item_features)
-        predictions = self.tf_projected_item_biases.eval(session=get_session(), feed_dict=feed_dict)
+
+        initializers = self._create_dataset_initializers(interactions_matrix=None,
+                                                         user_features_matrix=None,
+                                                         item_features_matrix=item_features)
+        get_session().run(initializers)
+        predictions = self.tf_projected_item_biases.eval(session=get_session())
         return predictions
 
     def save_model(self, directory_path):
@@ -783,13 +794,13 @@ class TensorRec(object):
         saver.save(sess=get_session(), save_path=session_path)
 
         # Break connections to the graph before saving the python object
-        self._clear_graph_hook_attrs()
+        self._break_graph_hooks()
         tensorrec_path = os.path.join(directory_path, 'tensorrec.pkl')
         with open(tensorrec_path, 'wb') as file:
             pickle.dump(file=file, obj=self)
 
         # Reconnect to the graph after saving
-        self._attach_graph_hook_attrs()
+        self._attach_graph_hooks()
 
     @classmethod
     def load_model(cls, directory_path):
@@ -809,5 +820,5 @@ class TensorRec(object):
         tensorrec_path = os.path.join(directory_path, 'tensorrec.pkl')
         with open(tensorrec_path, 'rb') as file:
             model = pickle.load(file=file)
-        model._attach_graph_hook_attrs()
+        model._attach_graph_hooks()
         return model

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -14,7 +14,7 @@ def sample_items(n_items, n_users, n_sampled_items, replace):
         for item in users_items:
             sample_indices.append((user, item))
 
-    return sample_indices
+    return np.array(sample_indices)
 
 
 def calculate_batched_alpha(num_batches, alpha):

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -2,8 +2,9 @@ import math
 import numpy as np
 import random
 import scipy.sparse as sp
-import six
 import tensorflow as tf
+
+from .input_utils import create_tensorrec_dataset_from_sparse_matrix
 
 
 def sample_items(n_items, n_users, n_sampled_items, replace):
@@ -28,55 +29,25 @@ def calculate_batched_alpha(num_batches, alpha):
     return batched_alpha
 
 
-def datasets_from_raw_input(raw_input, contains_counter):
+def datasets_from_raw_input(raw_input):
 
     if isinstance(raw_input, tf.data.Dataset):
         return [raw_input]
 
     if sp.issparse(raw_input):
-        return handle_sparse_matrix_input(input_sparse_matrix=raw_input, contains_counter=contains_counter)
+        return [create_tensorrec_dataset_from_sparse_matrix(raw_input)]
 
     if isinstance(raw_input, list) or isinstance(raw_input, set):
 
         if all([sp.issparse(input_val) for input_val in raw_input]):
-            return handle_sparse_matrix_list_input(input_sparse_matrix_list=raw_input,
-                                                   contains_counter=contains_counter)
+            return [create_tensorrec_dataset_from_sparse_matrix(input_sparse_matrix)
+                    for input_sparse_matrix in raw_input]
 
         if all([isinstance(input_val, tf.data.Dataset) for input_val in raw_input]):
             return raw_input
 
     raise ValueError('Input must be a scipy sparse matrix, an iterable of scipy sprase matrices, or a TensorFlow '
                      'Dataset')
-
-
-def handle_sparse_matrix_input(input_sparse_matrix, contains_counter):
-    return handle_sparse_matrix_list_input(input_sparse_matrix_list=[input_sparse_matrix],
-                                           contains_counter=contains_counter)
-
-
-def handle_sparse_matrix_list_input(input_sparse_matrix_list, contains_counter):
-    all_tensor_slices = [tensor_slices_from_sparse_matrix(input_matrix, contains_counter)
-                         for input_matrix in input_sparse_matrix_list]
-    return [tf.data.Dataset.from_tensor_slices(tensor_slices) for tensor_slices in all_tensor_slices]
-
-
-def tensor_slices_from_sparse_matrix(sparse_matrix, contains_counter):
-
-    if not isinstance(sparse_matrix, sp.coo_matrix):
-        sparse_matrix = sp.coo_matrix(sparse_matrix)
-
-    # "Actors" is used to signify "users or items" -- unused for interactions
-    n_actors = np.array([sparse_matrix.shape[0]], dtype=np.int64)
-    feature_indices = np.array([[pair for pair in six.moves.zip(sparse_matrix.row, sparse_matrix.col)]],
-                               dtype=np.int64)
-    feature_values = np.array([sparse_matrix.data], dtype=np.float32)
-
-    if contains_counter:
-        tensor_slices = (feature_indices, feature_values, n_actors)
-    else:
-        tensor_slices = (feature_indices, feature_values)
-
-    return tensor_slices
 
 
 def generate_dummy_data(num_users=15000, num_items=30000, interaction_density=.00045, num_user_features=200,
@@ -99,9 +70,9 @@ def generate_dummy_data(num_users=15000, num_items=30000, interaction_density=.0
     item_features = sp.rand(num_items, num_item_features, density=float(n_features_per_item) / num_item_features)
 
     if return_datasets:
-        interactions = handle_sparse_matrix_input(interactions, contains_counter=False)[0]
-        user_features = handle_sparse_matrix_input(user_features, contains_counter=True)[0]
-        item_features = handle_sparse_matrix_input(item_features, contains_counter=True)[0]
+        interactions = create_tensorrec_dataset_from_sparse_matrix(interactions)
+        user_features = create_tensorrec_dataset_from_sparse_matrix(user_features)
+        item_features = create_tensorrec_dataset_from_sparse_matrix(item_features)
 
     return interactions, user_features, item_features
 

--- a/test/datasets.py
+++ b/test/datasets.py
@@ -36,6 +36,7 @@ class IndicatorFeature(TransformerMixin):
 
 def _download_and_unpack_zip(url, local_path, skip_if_not_empty):
 
+    os.makedirs(local_path, exist_ok=True)
     files_in_dir = os.listdir(local_path)
     files_in_dir = [file for file in files_in_dir if file[0] != '.']  # Remove hidden files
 
@@ -48,7 +49,6 @@ def _download_and_unpack_zip(url, local_path, skip_if_not_empty):
     files = zip_file.namelist()
 
     local_paths = {}
-    os.makedirs(local_path, exist_ok=True)
     for filename in files:
         contents = zip_file.read(filename)
         write_path = os.path.join(local_path, filename)

--- a/test/test_tensorrec.py
+++ b/test/test_tensorrec.py
@@ -14,11 +14,15 @@ from tensorrec.util import generate_dummy_data_with_indicator, generate_dummy_da
 class TensorRecTestCase(TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        cls.interactions, cls.user_features, cls.item_features = generate_dummy_data(
+    def getDummyData(cls):
+        return generate_dummy_data(
             num_users=15, num_items=30, interaction_density=.5, num_user_features=200, num_item_features=200,
             n_features_per_user=20, n_features_per_item=20, pos_int_ratio=.5
         )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.interactions, cls.user_features, cls.item_features = cls.getDummyData()
 
         cls.standard_model = TensorRec(n_components=10)
         cls.standard_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
@@ -149,21 +153,6 @@ class TensorRecBiasedPrediction(TestCase):
         self.assertTrue(any(item_bias))  # Make sure it isn't all 0s
 
 
-class TensorRecNormalizedTestCase(TensorRecTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.interactions, cls.user_features, cls.item_features = generate_dummy_data_with_indicator(
-            num_users=10, num_items=20, interaction_density=.5
-        )
-
-        cls.standard_model = TensorRec(n_components=10, normalize_items=True, normalize_users=True)
-        cls.standard_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
-
-        cls.unbiased_model = TensorRec(n_components=10, normalize_items=True, normalize_users=True, biased=False)
-        cls.unbiased_model.fit(cls.interactions, cls.user_features, cls.item_features, epochs=10)
-
-
 class TensorRecNTastesTestCase(TensorRecTestCase):
 
     @classmethod
@@ -218,6 +207,16 @@ class TensorRecAttentionTestCase(TensorRecNTastesTestCase):
 
         # attn repr should have shape [n_tastes, n_users, n_components]
         self.assertEqual(user_attn_repr.shape, (3, self.user_features.shape[0], 10))
+
+
+class TensorRecDatasetInputTestCase(TensorRecTestCase):
+
+    @classmethod
+    def getDummyData(cls):
+        return generate_dummy_data(
+            num_users=15, num_items=30, interaction_density=.5, num_user_features=200, num_item_features=200,
+            n_features_per_user=20, n_features_per_item=20, pos_int_ratio=.5
+        )
 
 
 class TensorRecSavingTestCase(TestCase):


### PR DESCRIPTION
Closes #59 

1. Refactors the TensorRec graph to use Iterators/Datasets as inputs, rather than feeding bulk data in through the feed dict.
2. Removes `normalize_users` and `normalize_items` API.
3. Adds convenience methods for working with TFRecords and Datasets.
4. Adds tests for TFRecords and Datasets.

- [x] Graph uses Datasets
- [x] Accept Datasets as inputs
- [x] Accept string references to TFRecords as inputs
- [x] Allow user batching only when input is a sparse matrix