### PR TITLE
BUG: Fixes py_func failure on int32 return

### DIFF
--- a/tensorrec/tensorrec.py
+++ b/tensorrec/tensorrec.py
@@ -60,7 +60,7 @@ class TensorRec(object):
         major, minor, patch = tf.__version__.split(".")
         if int(major) < 1 or int(major) == 1 and int(minor) < 7:
             raise RuntimeError("""You need to have at least TensorFlow version 1.7 installed in order to use
-                               tensorrec problerly. You have currently installed TensofFlow: """ + tf.__version__)
+                               TensorRec properly. You have currently installed TensorFlow: """ + tf.__version__)
 
         # Arg Check
         if (n_components is None) or (n_tastes is None) or (user_repr_graph is None) or (item_repr_graph is None) \

--- a/tensorrec/util.py
+++ b/tensorrec/util.py
@@ -17,7 +17,7 @@ def sample_items(n_items, n_users, n_sampled_items, replace):
         for item in users_items:
             sample_indices.append((user, item))
 
-    return np.array(sample_indices)
+    return np.array(sample_indices, np.int64)
 
 
 def calculate_batched_alpha(num_batches, alpha):


### PR DESCRIPTION
Addresses https://github.com/jfkirk/tensorrec/issues/73

Failures can be a result of the np.random.choice method returning int32 values in some environments, while the TensorFlow py_func expects strictly int64 results.